### PR TITLE
added kwargs to traceplot

### DIFF
--- a/pystan/plots.py
+++ b/pystan/plots.py
@@ -3,8 +3,12 @@ import logging
 logger = logging.getLogger('pystan')
 
 
-def traceplot(fit, pars):
-    """Use pymc's traceplot to display parameters"""
+def traceplot(fit, pars, **kwargs):
+    """
+    Use pymc's traceplot to display parameters. 
+    
+    Additional arguments are passed to pymc.plots.traceplot.
+    """
     # FIXME: eventually put this in the StanFit object
     # FIXME: write a to_pymc(_trace) function
     try:
@@ -12,4 +16,4 @@ def traceplot(fit, pars):
     except ImportError:
         logger.critical("matplotlib required for plotting.")
         raise
-    return plots.traceplot(fit.extract(), pars)
+    return plots.traceplot(fit.extract(), pars, **kwargs)


### PR DESCRIPTION
Meant to enable users to pass additional arguments, such as figsize, to the pymc traceplot function.