### PR TITLE
misc._has_fileno should check for IOError also

### DIFF
--- a/pystan/misc.py
+++ b/pystan/misc.py
@@ -901,7 +901,7 @@ def _has_fileno(stream):
     """
     try:
         stream.fileno()
-    except (AttributeError, OSError, io.UnsupportedOperation):
+    except (AttributeError, OSError, IOError, io.UnsupportedOperation):
         return False
     return True
 


### PR DESCRIPTION
Apparently that's what Python 2 raises: https://docs.python.org/2/library/io.html#io.IOBase.fileno (whereas 3 does OSError).

Per @JanSchulz's comment on https://github.com/stan-dev/pystan/issues/3.