### PR TITLE
Explicit floor division

### DIFF
--- a/pystan/_chains.pyx
+++ b/pystan/_chains.pyx
@@ -195,13 +195,13 @@ def split_potential_scale_reduction(dict sim, int n):
         samples.clear()
         get_kept_samples(sim, chain, n, samples)
         split_chain.clear()
-        for i in range(n_samples/2):
+        for i in range(n_samples//2):
             split_chain.push_back(samples[i])
         split_chain_mean.push_back(stan_mean(split_chain))
         split_chain_var.push_back(stan_variance(split_chain))
 
         split_chain.clear()
-        for i in range(n_samples/2, n_samples):
+        for i in range(n_samples//2, n_samples):
             split_chain.push_back(samples[i])
         split_chain_mean.push_back(stan_mean(split_chain))
         split_chain_var.push_back(stan_variance(split_chain))


### PR DESCRIPTION
Without this Cython 0.23 on Python 3.4 fails to build pystan with two errors

```
(rpy2.3.8)[~/src/pystan]
|68 $ cython --version
Cython version 0.23
(rpy2.3.8)[~/src/pystan]
|69 $ python setup.py build
Compiling pystan/_api.pyx because it depends on /Users/sseabold/.virtualenvs/rpy2.3.8/lib/python3.4/site-packages/Cython/Includes/libcpp/string.pxd.
Compiling pystan/_chains.pyx because it depends on /Users/sseabold/.virtualenvs/rpy2.3.8/lib/python3.4/site-packages/Cython/Includes/libcpp/vector.pxd.
[1/2] Cythonizing pystan/_chains.pyx

Error compiling Cython file:
------------------------------------------------------------
...
    cdef vector[double] samples, split_chain
    for chain in range(n_chains):
        samples.clear()
        get_kept_samples(sim, chain, n, samples)
        split_chain.clear()
        for i in range(n_samples/2):
                               ^
------------------------------------------------------------

pystan/_chains.pyx:198:32: Cannot assign type 'double' to 'long'

Error compiling Cython file:
------------------------------------------------------------
...
            split_chain.push_back(samples[i])
        split_chain_mean.push_back(stan_mean(split_chain))
        split_chain_var.push_back(stan_variance(split_chain))

        split_chain.clear()
        for i in range(n_samples/2, n_samples):
                               ^
------------------------------------------------------------

pystan/_chains.pyx:204:32: Cannot assign type 'double' to 'long'
Traceback (most recent call last):
  File "setup.py", line 228, in <module>
    setup_package()
  File "setup.py", line 212, in setup_package
    metadata['ext_modules'] = cythonize(extensions)
  File "/Users/sseabold/.virtualenvs/rpy2.3.8/lib/python3.4/site-packages/Cython/Build/Dependencies.py", line 877, in cythonize
    cythonize_one(*args)
  File "/Users/sseabold/.virtualenvs/rpy2.3.8/lib/python3.4/site-packages/Cython/Build/Dependencies.py", line 997, in cythonize_one
    raise CompileError(None, pyx_file)
Cython.Compiler.Errors.CompileError: pystan/_chains.pyx
```