### PR TITLE
Remove over-wide assert from _chains

### DIFF
--- a/pystan/_chains.pyx
+++ b/pystan/_chains.pyx
@@ -125,7 +125,6 @@ def effective_sample_size(dict sim, int n):
         n_kept_samples = ns_kept[chain]
         chain_mean.push_back(get_chain_mean(sim, chain, n))
         chain_var.push_back(acov[chain][0] * n_kept_samples / (n_kept_samples-1))
-        assert chain_var[chain] < float('inf'), chain_var[chain]
 
     cdef double mean_var = stan_mean(chain_var)
     cdef double var_plus = mean_var * (n_samples-1) / n_samples


### PR DESCRIPTION
In `_chains.effective_sample_size`, remove the assertion that the variance is finite. For some infinities, it's better to let the code continue and have the user decide what to do with the output.

Closes #191 .