### PR TITLE
add a temp_dir variable to allow storing compiled models in other places

### DIFF
--- a/pystan/model.py
+++ b/pystan/model.py
@@ -248,6 +248,7 @@ class StanModel:
         nonce = abs(hash((self.model_name, time.time())))
         self.module_name = 'stanfit4{}_{}'.format(self.model_name, nonce)
         lib_dir = tempfile.mkdtemp(dir=temp_dir)
+        self.temp_dir = temp_dir
         pystan_dir = os.path.dirname(__file__)
         include_dirs = [
             lib_dir,
@@ -364,7 +365,7 @@ class StanModel:
 
     def __setstate__(self, state):
         self.__dict__.update(state)
-        lib_dir = tempfile.mkdtemp(dir=temp_dir)
+        lib_dir = tempfile.mkdtemp(dir=self.temp_dir)
         with io.open(os.path.join(lib_dir, self.module_filename), 'wb') as f:
             f.write(self.module_bytes)
         try:

--- a/pystan/model.py
+++ b/pystan/model.py
@@ -129,6 +129,11 @@ class StanModel:
     eigen_lib : string
         The path to a version of the Eigen C++ library to use instead of
         the one in the supplied with PyStan.
+    
+    temp_dir : string
+        The path to the temporary directory where compiled models are
+        stored during the execution. By default it is the directory
+        specified by tempfile.tempdir variable.
 
     verbose : boolean, False by default
         Indicates whether intermediate output should be piped to the console.
@@ -200,7 +205,8 @@ class StanModel:
     """
     def __init__(self, file=None, charset='utf-8', model_name="anon_model",
                  model_code=None, stanc_ret=None, boost_lib=None,
-                 eigen_lib=None, verbose=False, obfuscate_model_name=True):
+                 eigen_lib=None, verbose=False, obfuscate_model_name=True,
+                 temp_dir=None):
 
         if stanc_ret is None:
             stanc_ret = pystan.api.stanc(file=file,
@@ -241,7 +247,7 @@ class StanModel:
         # module_name needs to be unique so that each model instance has its own module
         nonce = abs(hash((self.model_name, time.time())))
         self.module_name = 'stanfit4{}_{}'.format(self.model_name, nonce)
-        lib_dir = tempfile.mkdtemp()
+        lib_dir = tempfile.mkdtemp(dir=temp_dir)
         pystan_dir = os.path.dirname(__file__)
         include_dirs = [
             lib_dir,
@@ -358,7 +364,7 @@ class StanModel:
 
     def __setstate__(self, state):
         self.__dict__.update(state)
-        lib_dir = tempfile.mkdtemp()
+        lib_dir = tempfile.mkdtemp(dir=temp_dir)
         with io.open(os.path.join(lib_dir, self.module_filename), 'wb') as f:
             f.write(self.module_bytes)
         try:


### PR DESCRIPTION
#### Summary:

Currently the compiled models (.so files) are stored in /tmp/ and deleted immediately after use. However the files are kept open by a process and occupy disk space. Therefore if in one python session many models are compiled, the amount of disk space consumed could be many gigabytes. That could lead to exhaustion of space in /tmp/. Therefore it makes sense to allow the compiled models to go in places other than /tmp.
#### Intended Effect:

Add temp_dir option to StanModel
#### How to Verify:

code = 'data{real x;}parameters{real y;}model{ x~normal(y,1);}'
model = pystan.StanModel(StringIO.StringIO(code), temp_dir=__PATH_TO_OTHER_DIR)
#### Side Effects:

None 
#### Documentation:

Added
#### Reviewer Suggestions:
#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):
Myself

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: GPLv3 (http://opensource.org/licenses/GPL-3.0)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
