### PR TITLE
BUG: Array indexing error in parameter error msg

### DIFF
--- a/pystan/model.py
+++ b/pystan/model.py
@@ -688,7 +688,7 @@ class StanModel:
                 pars = np.asarray(pars)
                 unmatched = pars[np.invert(np.in1d(pars, m_pars))]
                 msg = "No parameter(s): {}; sampling not done."
-                raise ValueError(msg.format(', '.join(pars[unmatched])))
+                raise ValueError(msg.format(', '.join(unmatched)))
         else:
             pars = m_pars
 

--- a/pystan/tests/test_basic_pars.py
+++ b/pystan/tests/test_basic_pars.py
@@ -77,6 +77,14 @@ class Test8Schools(unittest.TestCase):
         self.assertRaises(ValueError, fit.extract, 'theta')
         self.assertIsNotNone(fit.extract(permuted=False))
 
+    def test_8schools_bad_pars(self):
+        model = self.model
+        data = self.schools_dat
+        pars = ['mu', 'missing']  # 'missing' is not in the model
+        self.assertRaises(ValueError, model.sampling,
+                          data=data, pars=pars, iter=100)
+
+
 class TestParsLabels(unittest.TestCase):
 
     @classmethod


### PR DESCRIPTION
#### Summary:

In `pystan.model.StanModel.sampling`, users can request to store a subset of model parameters. The function contains a check that the requested parameters exist, but the error message contains `pars[unmatched]`, when `unmatched` is already an array of requested parameters which don't exist. This produces the error `IndexError: arrays used as indices must be of integer (or boolean) type`, which is difficult for users to decode.

#### Intended Effect:

A bad list of parameters to store will cause a `ValueError` with an error message listing the requested parameters not in the model.

#### How to Verify:

Call the `sampling` method with parameters not in the model and check the error type.

#### Side Effects:

None

#### Documentation:

None; this is a bugfix, so the original documentation holds.

#### Reviewer Suggestions: 

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):
Civis Analytics

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: GPLv3 (http://opensource.org/licenses/GPL-3.0)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

