### PR TITLE
Use -Os (like -O2) optimization for stanc

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -110,7 +110,7 @@ stan_macros = [
     ('FUSION_MAX_VECTOR_SIZE', 12),  # for parser, stan-dev/pystan#222
 ]
 extra_compile_args = [
-    '-O0',
+    '-Os',
     '-ftemplate-depth-256',
     '-Wno-unused-function',
     '-Wno-uninitialized',


### PR DESCRIPTION
To better support clang, optimization was reduced to -O0 in
stan-dev/pystan#33. In the naive hope that clang may have fixed its bugs
in the intervening three years and the desire to reduce the binary size
of PyStan wheels, this commit turns on -Os optimization which is
essentially -O2 optimization absent those optimizations which tend to
increase file size. See also stan-dev/stan#2025.