### PR TITLE
Remove deprecated <- from example in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -88,7 +88,7 @@ Example
     transformed parameters {
         real theta[J];
         for (j in 1:J)
-            theta[j] <- mu + tau * eta[j];
+            theta[j] = mu + tau * eta[j];
     }
     model {
         eta ~ normal(0, 1);


### PR DESCRIPTION
#### Summary:

Since "<-" is deprecated, the example in the README has to be changed

#### Intended Effect:

Example conforms to current notation

#### How to Verify:

README has been changed 



#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: GPLv3 (http://opensource.org/licenses/GPL-3.0)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

