### PR TITLE
Use pyximport to remove deprecated importlib function for Py3

### DIFF
--- a/pystan/model.py
+++ b/pystan/model.py
@@ -12,8 +12,6 @@ if PY2:
 else:
     from collections.abc import Callable, Iterable
 import datetime
-import importlib
-import imp
 import io
 import itertools
 import logging
@@ -45,12 +43,13 @@ logger = logging.getLogger('pystan')
 def load_module(module_name, module_path):
     """Load the module named `module_name` from  `module_path`
     independently of the Python version."""
-    if hasattr(importlib, 'find_loader'):
-        # Python 3
-        loader = importlib.find_loader(module_name, [module_path])
-        return loader.load_module()
+    if sys.version_info >= (3,0):
+        import pyximport
+        pyximport.install()
+        sys.path.append(module_path)
+        return __import__(module_name)
     else:
-        # Python 2.7
+        import imp
         module_info = imp.find_module(module_name, [module_path])
         return imp.load_module(module_name, *module_info)
 


### PR DESCRIPTION
#### Summary:

Resolves #231 
Uses pyximport to make importable the "normal" way

#### Intended Effect:

Get rid of `importlib`, which is deprecated. Originally the idea was to replace with `find_spec`, but that doesn't work with pyx. But the `pyximport` module that's installed with Cython makes pyx modules importable. I thought it'd work for both Python 2 and 3, but I got compilation errors for Python 2, so I just changed it for Python 3. Also, moved the relevant imports into the `if...else` and replaced the clause with a version check for Python 3.

#### How to Verify:

Running the example in the README worked, did it only on Linux though

#### Side Effects:

None

#### Documentation:

#### Reviewer Suggestions: 

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: GPLv3 (http://opensource.org/licenses/GPL-3.0)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

