### PR TITLE
Add default value of algorithm in the sampling method

### DIFF
--- a/pystan/model.py
+++ b/pystan/model.py
@@ -554,7 +554,7 @@ class StanModel:
 
         algorithm : {"NUTS", "HMC", "Fixed_param"}, optional
             One of algorithms that are implemented in Stan such as the No-U-Turn
-            sampler (NUTS, Hoffman and Gelman 2011), static HMC, or ``Fixed_param``.
+            sampler (Default, NUTS, Hoffman and Gelman 2011), static HMC, or ``Fixed_param``.
 
         init : {0, '0', 'random', function returning dict, list of dict}, optional
             Specifies how initial parameter values are chosen: 0 or '0'

--- a/pystan/model.py
+++ b/pystan/model.py
@@ -554,7 +554,8 @@ class StanModel:
 
         algorithm : {"NUTS", "HMC", "Fixed_param"}, optional
             One of algorithms that are implemented in Stan such as the No-U-Turn
-            sampler (Default, NUTS, Hoffman and Gelman 2011), static HMC, or ``Fixed_param``.
+            sampler (NUTS, Hoffman and Gelman 2011), static HMC, or ``Fixed_param``.
+            Default is NUTS.
 
         init : {0, '0', 'random', function returning dict, list of dict}, optional
             Specifies how initial parameter values are chosen: 0 or '0'


### PR DESCRIPTION
#### Summary:

Indicate the default value of the `algorithm` argument of the `sampling` method is `NUTS`, which was not immediately clear from the API documentation.

#### Intended Effect:

#### How to Verify:

#### Side Effects:

#### Documentation:

#### Reviewer Suggestions: 

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: GPLv3 (http://opensource.org/licenses/GPL-3.0)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
