### PR TITLE
Update PyStan to Stan 2.14.0

### DIFF
--- a/pystan/model.py
+++ b/pystan/model.py
@@ -247,10 +247,10 @@ class StanModel:
             lib_dir,
             pystan_dir,
             os.path.join(pystan_dir, "stan", "src"),
-            os.path.join(pystan_dir, "stan", "lib", "stan_math_2.12.0"),
-            os.path.join(pystan_dir, "stan", "lib", "stan_math_2.12.0", "lib", "eigen_3.2.9"),
-            os.path.join(pystan_dir, "stan", "lib", "stan_math_2.12.0", "lib", "boost_1.60.0"),
-            os.path.join(pystan_dir, "stan", "lib", "stan_math_2.12.0", "lib", "cvodes_2.8.2", "include"),
+            os.path.join(pystan_dir, "stan", "lib", "stan_math_2.14.0"),
+            os.path.join(pystan_dir, "stan", "lib", "stan_math_2.14.0", "lib", "eigen_3.2.9"),
+            os.path.join(pystan_dir, "stan", "lib", "stan_math_2.14.0", "lib", "boost_1.62.0"),
+            os.path.join(pystan_dir, "stan", "lib", "stan_math_2.14.0", "lib", "cvodes_2.9.0", "include"),
             np.get_include(),
         ]
 

--- a/pystan/stan_fit.hpp
+++ b/pystan/stan_fit.hpp
@@ -15,7 +15,9 @@
 #include <boost/random/additive_combine.hpp> // L'Ecuyer RNG
 #include <boost/random/uniform_real_distribution.hpp>
 
-#include <stan/model/util.hpp>
+#include <stan/model/test_gradients.hpp>
+
+#include <stan/interface_callbacks/writer/base_writer.hpp>
 
 #include <stan/mcmc/base_adaptation.hpp>
 #include <stan/mcmc/base_adapter.hpp>
@@ -62,6 +64,7 @@
 #include <stan/services/io/do_print.hpp>
 #include <stan/services/io/write_error_msg.hpp>
 #include <stan/services/io/write_iteration.hpp>
+//#include <stan/services/io/write_iteration_csv.hpp>
 #include <stan/services/io/write_model.hpp>
 #include <stan/services/io/write_stan.hpp>
 #include <stan/services/init/initialize_state.hpp>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
-# NOTE: these requirements need to be fixed in setup.py as well
+# NOTE: these requirements need to be listed in `install_requires` in setup.py
+# Cython 0.25.1 does not work with PyStan.
 numpy>=1.7,<2.0
-Cython>=0.22,<0.25
+Cython>=0.22,!=0.25.1

--- a/setup.py
+++ b/setup.py
@@ -99,10 +99,10 @@ from distutils.errors import CCompilerError, DistutilsError
 from distutils.extension import Extension
 
 stan_include_dirs = ['pystan/stan/src',
-                     'pystan/stan/lib/stan_math_2.12.0/',
-                     'pystan/stan/lib/stan_math_2.12.0/lib/eigen_3.2.9',
-                     'pystan/stan/lib/stan_math_2.12.0/lib/boost_1.60.0',
-                     'pystan/stan/lib/stan_math_2.12.0/lib/cvodes_2.8.2/include']
+                     'pystan/stan/lib/stan_math_2.14.0/',
+                     'pystan/stan/lib/stan_math_2.14.0/lib/eigen_3.2.9',
+                     'pystan/stan/lib/stan_math_2.14.0/lib/boost_1.62.0',
+                     'pystan/stan/lib/stan_math_2.14.0/lib/cvodes_2.9.0/include']
 stan_macros = [
     ('BOOST_RESULT_OF_USE_TR1', None),
     ('BOOST_NO_DECLTYPE', None),

--- a/setup.py
+++ b/setup.py
@@ -86,7 +86,7 @@ if len(set(('develop', 'release', 'bdist_egg', 'bdist_rpm',
             )).intersection(sys.argv)) > 0:
     import setuptools
     extra_setuptools_args = dict(
-        install_requires=['Cython>=0.22,<0.25', 'numpy >= 1.7'],
+        install_requires=['Cython>=0.22,!=0.25.1', 'numpy >= 1.7'],
         zip_safe=False, # the package can run out of an .egg file
         include_package_data=True,
     )


### PR DESCRIPTION
Title says it all. This just concerns the Stan 2.14.0 source (tag: v2.14.0) and minor CI matters.