### PR TITLE
Clean up multiprocessing after KeyboardInterrupt

### DIFF
--- a/pystan/model.py
+++ b/pystan/model.py
@@ -76,10 +76,8 @@ def _map_parallel(function, args, n_jobs):
     if multiprocessing and int(n_jobs) not in (0, 1):
         if n_jobs == -1:
             n_jobs = None
-        pool = multiprocessing.Pool(processes=n_jobs)
-        map_result = pool.map(function, args)
-        pool.close()
-        pool.join()
+        with multiprocessing.Pool(processes=n_jobs) as pool:
+            map_result = pool.map(function, args)
     else:
         map_result = list(map(function, args))
     return map_result


### PR DESCRIPTION
Use a contextmanager to properly clean up after use of
multiprocessing.Pool. Correct use of multiprocessing.Pool
in any event and possible solution to program hang.

Fixes #281.

Thanks to @ahartikainen for the suggestion and @fonnesbeck for the
bug report.

#### Summary:

See #281