### PR TITLE
TST: update test checking gradient error exception message propogation

### DIFF
--- a/pystan/tests/test_rstan_stanfit.py
+++ b/pystan/tests/test_rstan_stanfit.py
@@ -20,8 +20,7 @@ class TestStanfit(unittest.TestCase):
         }
         """
         sm = StanModel(model_code=code)
-        assertRaisesRegex = self.assertRaisesRegexp if PY2 else self.assertRaisesRegex
-        with assertRaisesRegex(RuntimeError, ''):
+        with self.assertRaises(RuntimeError):
             sm.sampling(init='0', iter=1, chains=1)
 
     def test_grad_log(self):

--- a/pystan/tests/test_user_inits.py
+++ b/pystan/tests/test_user_inits.py
@@ -72,13 +72,9 @@ class TestUserInits(unittest.TestCase):
         }
         """
         data = self.data
-        # NOTE: we are only specifying 'mu' and not 'sigma'
-        # This behavior works now.
-        try:
-            pystan.stan(model_code=model_code, iter=10, chains=1, seed=2,
-                        data=data, init=[dict(mu=4)], warmup=0)
-        except RuntimeError:
-            self.fail("pystan.stan() raised RuntimeError on partial init")
+        # NOTE: we are only specifying 'mu' and not 'sigma' (partial inits)
+        fit = pystan.stan(model_code=model_code, iter=10, chains=1, seed=2, data=data, init=[dict(mu=4)], warmup=0)
+        self.assertIsNotNone(fit)
 
 
 class TestUserInitsMatrix(unittest.TestCase):


### PR DESCRIPTION
Minor update to a test to reflect a more informative C++ exception in stan services.

Depends on stan-dev/stan#2203