### PR TITLE
Expose constrain_pars method

### DIFF
--- a/pystan/stanfit4model.pyx
+++ b/pystan/stanfit4model.pyx
@@ -718,6 +718,12 @@ cdef class StanFit4Model:
         m = np.row_stack([mean_pars, mean_lp__])
         return m
 
+    def constrain_pars(self, np.ndarray[double, ndim=1, mode="c"] upar not None):
+        """Transform parameters from unconstrained space to defined support"""
+        cdef vector[double] constrained
+        constrained = self.thisptr.constrain_pars(upar)
+        return np.asarray(constrained)
+
     def unconstrain_pars(self, par):
         """Transform parameters from defined support to unconstrained space"""
         cdef vector[double] unconstrained


### PR DESCRIPTION
#### Summary:
Expose the constrain_pars method from Stan to PyStan.

#### Intended Effect:
Being able to call constrain_pars from PyStan to transform unconstrained parameters to constrained parameters.

#### How to Verify:
Check that unconstrain_pars and constrain_pars are inverse to each other.

#### Side Effects:
None

#### Documentation:

#### Reviewer Suggestions: 

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: GPLv3 (http://opensource.org/licenses/GPL-3.0)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
