### PR TITLE
WIP: Interfacing with External C++ Code

### DIFF
--- a/pystan/_api.pyx
+++ b/pystan/_api.pyx
@@ -5,11 +5,12 @@
 # This file is licensed under Version 3.0 of the GNU General Public
 # License. See LICENSE for a text of the license.
 #-----------------------------------------------------------------------------
+from libcpp cimport bool
 from pystan.stanc cimport PyStancResult, stanc as c_stanc
 
-def stanc(bytes model_stancode, bytes model_name):
+def stanc(bytes model_stancode, bytes model_name, bool allow_undefined):
     cdef PyStancResult result
-    c_stanc(model_stancode, model_name, result)
+    c_stanc(model_stancode, model_name, allow_undefined, result)
     return {'status': result.status,
             'msg': result.msg.decode('utf-8'),
             'model_cppname': result.model_cppname.decode('ascii'),

--- a/pystan/api.py
+++ b/pystan/api.py
@@ -17,7 +17,7 @@ logger = logging.getLogger('pystan')
 
 
 def stanc(file=None, charset='utf-8', model_code=None, model_name="anon_model",
-          verbose=False, obfuscate_model_name=True):
+          verbose=False, obfuscate_model_name=True, allow_undefined=False):
     """Translate Stan model specification into C++ code.
 
     Parameters
@@ -49,6 +49,10 @@ def stanc(file=None, charset='utf-8', model_code=None, model_name="anon_model",
         If False the model name in the generated C++ code will not be made
         unique by the insertion of randomly generated characters.
         Generally it is recommended that this parameter be left as True.
+
+    allow_undefined : boolean, False by default
+        If True, the C++ code can be written even if there are undefined
+        functions.
 
     Returns
     -------
@@ -123,7 +127,7 @@ def stanc(file=None, charset='utf-8', model_code=None, model_name="anon_model",
 
     model_name_bytes = model_name.encode('ascii')
 
-    result = pystan._api.stanc(model_code_bytes, model_name_bytes)
+    result = pystan._api.stanc(model_code_bytes, model_name_bytes, allow_undefined)
     if result['status'] == -1:  # EXCEPTION_RC is -1
         msg = result['msg']
         if PY2:
@@ -143,7 +147,7 @@ def stan(file=None, model_name="anon_model", model_code=None, fit=None,
          data=None, pars=None, chains=4, iter=2000, warmup=None, thin=1,
          init="random", seed=None, algorithm=None, control=None, sample_file=None,
          diagnostic_file=None, verbose=False, boost_lib=None,
-         eigen_lib=None, n_jobs=-1, **kwargs):
+         eigen_lib=None, n_jobs=-1, allow_undefined=False, **kwargs):
     """Fit a model using Stan.
 
     Parameters
@@ -285,6 +289,10 @@ def stan(file=None, model_name="anon_model", model_code=None, fit=None,
         Sample in parallel. If -1 all CPUs are used. If 1, no parallel
         computing code is used at all, which is useful for debugging.
 
+    allow_undefined : boolean, False by default
+        If True, the C++ code can be written even if there are undefined
+        functions.
+
     Returns
     -------
 
@@ -316,12 +324,12 @@ def stan(file=None, model_name="anon_model", model_code=None, fit=None,
         Argument `refresh` can be used to control how to indicate the progress
         during sampling (i.e. show the progress every \code{refresh} iterations).
         By default, `refresh` is `max(iter/10, 1)`.
-        
+
     obfuscate_model_name : boolean, optional
         `obfuscate_model_name` is only valid if `fit` is None. True by default.
         If False the model name in the generated C++ code will not be made
         unique by the insertion of randomly generated characters.
-        Generally it is recommended that this parameter be left as True. 
+        Generally it is recommended that this parameter be left as True.
 
     Examples
     --------
@@ -380,7 +388,8 @@ def stan(file=None, model_name="anon_model", model_code=None, fit=None,
     else:
         m = StanModel(file=file, model_name=model_name, model_code=model_code,
                       boost_lib=boost_lib, eigen_lib=eigen_lib,
-                      obfuscate_model_name=obfuscate_model_name, verbose=verbose)
+                      obfuscate_model_name=obfuscate_model_name, verbose=verbose,
+                      allow_undefined=allow_undefined)
     # check that arguments in kwargs are valid
     valid_args = {"chain_id", "init_r", "test_grad", "append_samples", "enable_random_init",
                   "refresh", "control"}

--- a/pystan/model.py
+++ b/pystan/model.py
@@ -131,6 +131,14 @@ class StanModel:
         Indicates whether intermediate output should be piped to the console.
         This output may be useful for debugging.
 
+    allow_undefined : boolean, False by default
+        If True, the C++ code can be written even if there are undefined
+        functions.
+
+    includes : list, None by default
+        If not None, the elements of this list will be assumed to be the
+        names of custom C++ header files that should be included.
+
     kwargs : keyword arguments
         Additional arguments passed to `stanc`.
 
@@ -198,7 +206,8 @@ class StanModel:
     def __init__(self, file=None, charset='utf-8', model_name="anon_model",
                  model_code=None, stanc_ret=None, boost_lib=None,
                  eigen_lib=None, verbose=False, obfuscate_model_name=True,
-                 extra_compile_args=None):
+                 extra_compile_args=None,
+                 allow_undefined=False, includes=None):
 
         if stanc_ret is None:
             stanc_ret = pystan.api.stanc(file=file,
@@ -206,7 +215,8 @@ class StanModel:
                                          model_code=model_code,
                                          model_name=model_name,
                                          verbose=verbose,
-                                         obfuscate_model_name=obfuscate_model_name)
+                                         obfuscate_model_name=obfuscate_model_name,
+                                         allow_undefined=allow_undefined)
 
         if not isinstance(stanc_ret, dict):
             raise ValueError("stanc_ret must be an object returned by stanc.")
@@ -253,6 +263,15 @@ class StanModel:
         ]
 
         model_cpp_file = os.path.join(lib_dir, self.model_cppname + '.hpp')
+        if includes is not None:
+            code = ""
+            for fn in includes:
+                code += "#include \"{0}\"\n".format(os.path.abspath(fn))
+            # ind = self.model_cppcode.index("class {0} : public prob_grad".format(self.model_cppname))
+            ind = self.model_cppcode.index("static int current_statement_begin__;")
+            self.model_cppcode = "\n".join([
+                self.model_cppcode[:ind], code, self.model_cppcode[ind:]
+            ])
         with io.open(model_cpp_file, 'w', encoding='utf-8') as outfile:
             outfile.write(self.model_cppcode)
 

--- a/pystan/stanc.hpp
+++ b/pystan/stanc.hpp
@@ -24,7 +24,7 @@ std::string stan_version() {
   return stan_version;
 }
 
-int stanc(std::string model_stancode, std::string model_name, PyStancResult& result) {
+int stanc(std::string model_stancode, std::string model_name, bool allow_undefined, PyStancResult& result) {
   static const int SUCCESS_RC = 0;
   static const int EXCEPTION_RC = -1;
   static const int PARSE_FAIL_RC = -2;
@@ -43,7 +43,7 @@ int stanc(std::string model_stancode, std::string model_name, PyStancResult& res
   std::istringstream in(mcode_);
   try {
     bool valid_model
-      = stan::lang::compile(&std::cerr,in,out,mname_);
+      = stan::lang::compile(&std::cerr,in,out,mname_,allow_undefined);
     if (!valid_model) {
       result.status = PARSE_FAIL_RC;
       return PARSE_FAIL_RC;

--- a/pystan/stanc.pxd
+++ b/pystan/stanc.pxd
@@ -15,4 +15,4 @@ cdef extern from "stanc.hpp":
         string msg
         string model_cppname
         string cppcode
-    int stanc(string& model_stancode, string& model_name, PyStancResult&)
+    int stanc(string& model_stancode, string& model_name, bool allow_undefined, PyStancResult&)


### PR DESCRIPTION
#### Summary:

This is not meant to be merged as it is and please feel free to ignore!

I'm not sure if you want to include support for this or even if it is a good idea, but I needed it for my own uses so I wanted to open this to see if there is broader interest. Basically, I wanted to allow something like the RStan example: [Interfacing with External C++ Code](https://cran.r-project.org/web/packages/rstan/vignettes/external.html) using Python. This meant that I needed to add support for the `allow_undefined` argument in `stan::lang::compile` and inject some `include`s into the generated C++ code. This is undocumented and there are no tests because I just wanted to see if there was interest in adding this feature. If not, I'm happy to close this pull request!

#### Intended Effect:

This simplifies the inclusion of external C++ functions into PyStan models.

#### How to Verify:

#### Side Effects:

#### Documentation:

None yet but there is a minimal demo here: https://gist.github.com/dfm/07f5d1e41dc7e3e862389d811db70369

#### Reviewer Suggestions: 

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Daniel Foreman-Mackey

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: GPLv3 (http://opensource.org/licenses/GPL-3.0)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
