### PR TITLE
Raise ValueError if random seed larger than max uint

### DIFF
--- a/pystan/constants.py
+++ b/pystan/constants.py
@@ -1,4 +1,4 @@
-MAX_UINT = 2**31 - 1  # simpler than ctypes.uint(-1).value, I think
+MAX_UINT = 2**31 - 1  # conservative choice, maximum unsigned int on 32-bit Python 2.7
 EPSILON = 1e-6
 
 try:

--- a/pystan/misc.py
+++ b/pystan/misc.py
@@ -666,8 +666,7 @@ def _check_seed(seed):
                 warnings.warn("`seed` may not be negative")
                 seed = None
             elif seed > MAX_UINT:
-                warnings.warn("`seed` is too large; max is {}".format(MAX_UINT))
-                seed = None
+                raise ValueError('`seed` is too large; max is {}'.format(MAX_UINT))
     elif isinstance(seed, np.random.RandomState):
         seed = seed.randint(0, MAX_UINT)
     elif seed is not None:

--- a/pystan/tests/test_misc.py
+++ b/pystan/tests/test_misc.py
@@ -45,7 +45,11 @@ class TestMisc(unittest.TestCase):
         self.assertEqual(misc._check_seed(10.5), 10)
         self.assertTrue(is_valid_seed(misc._check_seed(np.random.RandomState())))
         self.assertTrue(is_valid_seed(misc._check_seed(-1)))
-        self.assertTrue(is_valid_seed(misc._check_seed(MAX_UINT + 1)))
+
+    def test_check_seed_gt_max_uint(self):
+        assertRaisesRegex = self.assertRaisesRegexp if PY2 else self.assertRaisesRegex
+        with assertRaisesRegex(ValueError, '`seed` is too large'):
+            misc._check_seed(MAX_UINT + 1)
 
     def test_stan_rdump(self):
         data = OrderedDict(x=1, y=0, z=[1, 2, 3], Phi=np.array([[1, 2], [3, 4]]))


### PR DESCRIPTION
Previously PyStan followed RStan's pattern of re-drawing a valid random
seed.

Closes #316.