### PR TITLE
Raise ValueError if non-int passed as thin, warmup, or iter

### DIFF
--- a/pystan/model.py
+++ b/pystan/model.py
@@ -15,7 +15,7 @@ import datetime
 import io
 import itertools
 import logging
-from numbers import Number
+import numbers
 import os
 import platform
 import shutil
@@ -472,7 +472,7 @@ class StanModel:
         del m_pars[idx_of_lp]
         del p_dims[idx_of_lp]
 
-        if isinstance(init, Number):
+        if isinstance(init, numbers.Number):
             init = str(init)
         elif isinstance(init, Callable):
             init = init()
@@ -657,6 +657,8 @@ class StanModel:
             data = {}
         if warmup is None:
             warmup = int(iter // 2)
+        if not all(isinstance(arg, numbers.Integral) for arg in (iter, thin, warmup)):
+            raise ValueError('only integer values allowed as `iter`, `thin`, and `warmup`.')
         algorithms = ("NUTS", "HMC", "Fixed_param")  # , "Metropolis")
         algorithm = "NUTS" if algorithm is None else algorithm
         if algorithm not in algorithms:
@@ -844,7 +846,7 @@ class StanModel:
         m_pars = fit._get_param_names()
         p_dims = fit._get_param_dims()
 
-        if isinstance(init, Number):
+        if isinstance(init, numbers.Number):
             init = str(init)
         elif isinstance(init, Callable):
             init = init()

--- a/pystan/tests/test_basic.py
+++ b/pystan/tests/test_basic.py
@@ -88,6 +88,11 @@ class TestBernoulli(unittest.TestCase):
         with assertRaisesRegex(RuntimeError, 'variable does not exist'):
             fit = self.model.sampling(data=bad_data)
 
+    def test_bernoulli_sampling_invalid_argument(self):
+        assertRaisesRegex = self.assertRaisesRegexp if PY2 else self.assertRaisesRegex
+        with assertRaisesRegex(ValueError, 'only integer values allowed'):
+            self.model.sampling(thin=2.0, data=self.bernoulli_data)
+
     def test_bernoulli_extract(self):
         fit = self.fit
         extr = fit.extract(permuted=True)


### PR DESCRIPTION
Thanks to @ahartikainen for the suggested fix.

Closes #302.