### PR TITLE
Avoid using context manager with multiprocessing.Pool

### DIFF
--- a/pystan/model.py
+++ b/pystan/model.py
@@ -76,8 +76,12 @@ def _map_parallel(function, args, n_jobs):
     if multiprocessing and int(n_jobs) not in (0, 1):
         if n_jobs == -1:
             n_jobs = None
-        with multiprocessing.Pool(processes=n_jobs) as pool:
+        try:
+            pool = multiprocessing.Pool(processes=n_jobs)
             map_result = pool.map(function, args)
+        finally:
+            pool.close()
+            pool.join()
     else:
         map_result = list(map(function, args))
     return map_result


### PR DESCRIPTION
Python 2.7 does not support using multiprocessing.Pool with a
context pool.

NOTE: PyStan will not support Python 2.7 after 2020!

Closes #331