### PR TITLE
Handle unsigned integers in data

### DIFF
--- a/pystan/misc.py
+++ b/pystan/misc.py
@@ -359,7 +359,7 @@ def _split_data(data):
     # map<string, pair<vector<int>, vector<size_t>>> so prepare
     # them accordingly.
     for k, v in data.items():
-        if np.issubdtype(np.asarray(v).dtype, int):
+        if np.issubdtype(np.asarray(v).dtype, np.integer):
             data_i.update({k.encode('utf-8'): np.asarray(v, dtype=int)})
         elif np.issubdtype(np.asarray(v).dtype, float):
             data_r.update({k.encode('utf-8'): np.asarray(v, dtype=float)})


### PR DESCRIPTION
_split_data now handles unsigned integers (e.g., numpy.uint8)
by converting them into integers.

Thanks to @tyarkoni for the report and @ahartikainen for the suggested
fix.

Closes #303