### PR TITLE
Release PyStan 2.16.0.0

### DIFF
--- a/doc/getting_started.rst
+++ b/doc/getting_started.rst
@@ -43,10 +43,10 @@ dependencies, then issue the commands:
 
 ::
 
-   wget https://pypi.python.org/packages/source/p/pystan/pystan-2.15.0.1.tar.gz
+   wget https://pypi.python.org/packages/source/p/pystan/pystan-2.16.0.0.tar.gz
    # alternatively, use curl, or a web browser
-   tar zxvf pystan-2.15.0.1.tar.gz
-   cd pystan-2.15.0.1
+   tar zxvf pystan-2.16.0.0.tar.gz
+   cd pystan-2.16.0.0
    python setup.py install
    cd ..  # change out of the source directory before importing pystan
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -6,6 +6,15 @@
  What's New
 ============
 
+v2.16.0.0 (22. June 2017)
+========================
+- Update Stan source to v2.16.0 (`release notes <https://github.com/stan-dev/stan/releases/tag/v2.16.0>`_),
+- Ari Hartikainen (Aalto University) @ahartikainen joins the Stan development team. 🎉
+- Added ``pystan.lookup`` (contributed by Marco Inacio, @randommm)
+- NOTE: Stan v2.16.0 is the final release which will not require a C++11 compatible compiler. Future
+  releases will require a C+11 compatible compiler. The vast majority of users have a compatible
+  compiler.
+
 v2.15.0.1 (2. May 2017)
 ========================
 - Python 2.7 compatibility fix (#332). Thanks to @monga for the report.

--- a/pystan/__init__.py
+++ b/pystan/__init__.py
@@ -17,4 +17,4 @@ if len(logger.handlers) == 1:
     logging.basicConfig(level=logging.INFO)
 
 # following PEP 386
-__version__ = '2.15.0.2dev'
+__version__ = '2.16.0.0'


### PR DESCRIPTION
Follows steps described in ``doc/release-howto.rst``.

Closes #353