### PR TITLE
CI: split tests up, avoid CI timeout

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,11 +13,14 @@ compiler:
   - clang
   - gcc
 env:
-  - TRAVIS_PYTHON_VERSION=2.7
-  - TRAVIS_PYTHON_VERSION=3.3
-  - TRAVIS_PYTHON_VERSION=3.4
-  - TRAVIS_PYTHON_VERSION=3.5
-  - TRAVIS_PYTHON_VERSION=3.6
+  - TRAVIS_PYTHON_VERSION=2.7 TESTS_EXCLUDE_RE='^test_[a-p].*\.py'
+  - TRAVIS_PYTHON_VERSION=3.4 TESTS_EXCLUDE_RE='^test_[a-p].*\.py'
+  - TRAVIS_PYTHON_VERSION=3.5 TESTS_EXCLUDE_RE='^test_[a-p].*\.py'
+  - TRAVIS_PYTHON_VERSION=3.6 TESTS_EXCLUDE_RE='^test_[a-p].*\.py'
+  - TRAVIS_PYTHON_VERSION=2.7 TESTS_EXCLUDE_RE='^test_[^a-p].*\.py'
+  - TRAVIS_PYTHON_VERSION=3.4 TESTS_EXCLUDE_RE='^test_[^a-p].*\.py'
+  - TRAVIS_PYTHON_VERSION=3.5 TESTS_EXCLUDE_RE='^test_[^a-p].*\.py'
+  - TRAVIS_PYTHON_VERSION=3.6 TESTS_EXCLUDE_RE='^test_[^a-p].*\.py'
 notifications:
   email:
     recipients:
@@ -25,4 +28,4 @@ notifications:
     on_success: change
     on_failure: always
 install: source continuous_integration/install.sh
-script: bash continuous_integration/test_script.sh
+script: bash continuous_integration/test_script.sh --exclude="$TESTS_EXCLUDE_RE"

--- a/continuous_integration/test_script.sh
+++ b/continuous_integration/test_script.sh
@@ -20,10 +20,10 @@ SKLEARN_SKIP_NETWORK_TESTS=1
 export PYSTAN_SKIP_PLOT_TESTS=1
 
 if [[ $TRAVIS_OS_NAME == 'linux' ]]; then
-    DISPLAY=:99.0 JOBLIB_MULTIPROCESSING=0 nosetests -w /tmp pystan
+    DISPLAY=:99.0 JOBLIB_MULTIPROCESSING=0 nosetests -w /tmp pystan $@
 fi
 
 if [[ $TRAVIS_OS_NAME == 'osx' ]]; then
     # skip DISPLAY setting and hope for the best
-    JOBLIB_MULTIPROCESSING=0 nosetests -w /tmp pystan
+    JOBLIB_MULTIPROCESSING=0 nosetests -w /tmp pystan $@
 fi


### PR DESCRIPTION
Tests need to finish in less than 50 minutes. This commit splits the tests up into two batches each of which should finish in less than 50 minutes.

``nosetests`` is used in the tests currently. In the future, some more modern test framework should be used.

Before merging, check to see if any tests are getting lost. The total number of tests should be 95.

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: GPLv3 (http://opensource.org/licenses/GPL-3.0)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
