### PR TITLE
Add Windows gcc support

### DIFF
--- a/pystan/model.py
+++ b/pystan/model.py
@@ -26,11 +26,19 @@ import time
 import warnings
 
 import distutils
-from distutils.core import Extension
+
+try:
+    # MSVC 2017 support (setuptools >= 34.4.0)
+    from setuptools import Extension
+except ImportError:
+    from distutils.core import Extension
 
 import Cython
 from Cython.Build.Inline import _get_build_extension
 from Cython.Build.Dependencies import cythonize
+
+# GCC detection
+import subprocess
 
 import numpy as np
 
@@ -134,7 +142,12 @@ class StanModel:
     verbose : boolean, False by default
         Indicates whether intermediate output should be piped to the console.
         This output may be useful for debugging.
-
+    
+    compiler : string, None by default
+        Only for Windows. Choose compiler type. 
+        - for GCC use 'gcc' or 'mingw32', 
+        - for Microsoft Visual C++ use 'msvc'
+    
     kwargs : keyword arguments
         Additional arguments passed to `stanc`.
 
@@ -202,7 +215,7 @@ class StanModel:
     def __init__(self, file=None, charset='utf-8', model_name="anon_model",
                  model_code=None, stanc_ret=None, boost_lib=None,
                  eigen_lib=None, verbose=False, obfuscate_model_name=True,
-                 extra_compile_args=None):
+                 extra_compile_args=None, compiler=None):
 
         if stanc_ret is None:
             stanc_ret = pystan.api.stanc(file=file,
@@ -274,6 +287,10 @@ class StanModel:
             ('BOOST_NO_DECLTYPE', None),
             ('BOOST_DISABLE_ASSERTS', None),
         ]
+        
+        # create here to allow compiler injection on Windows
+        build_extension = _get_build_extension()
+        
         # compile stan models with optimization (-O2)
         # (stanc is compiled without optimization (-O0) currently, see #33)
         if extra_compile_args is None:
@@ -284,7 +301,25 @@ class StanModel:
                 '-Wno-uninitialized',
             ]
             if platform.platform().startswith('Win'):
-                extra_compile_args = ['/EHsc', '-DBOOST_DATE_TIME_NO_LIB']
+                # sanitize input
+                if compiler == 'gcc':
+                    compiler = 'mingw32'
+                # inject the compiler kw
+                if compiler is not None:
+                    build_extension.compiler = compiler
+                # inject gcc (mingw32) if found else use msvc
+                elif build_extension.compiler is None:
+                    # run subprocess without output
+                    with open(os.devnull, 'w') as DEVNULL:
+                        try:
+                            subprocess.call(["gcc", "--version"], stdout=DEVNULL)
+                        except FileNotFoundError:
+                            build_extension.compiler = "msvc"
+                        else:
+                            build_extension.compiler = "mingw32"
+                
+                if build_extension.compiler == "msvc":
+                    extra_compile_args = ['/EHsc', '-DBOOST_DATE_TIME_NO_LIB']
 
         distutils.log.set_verbosity(verbose)
         extension = Extension(name=self.module_name,
@@ -295,7 +330,7 @@ class StanModel:
                               extra_compile_args=extra_compile_args)
 
         cython_include_dirs = ['.', pystan_dir]
-        build_extension = _get_build_extension()
+        
         build_extension.extensions = cythonize([extension],
                                                include_path=cython_include_dirs,
                                                quiet=not verbose)

--- a/pystan/model.py
+++ b/pystan/model.py
@@ -26,16 +26,7 @@ import time
 import warnings
 
 import distutils
-from distutils import ccompiler
-
-if ccompiler.get_default_compiler() == 'msvc':
-    try:
-        # MSVC 2017 support (setuptools >= 34.4.0)
-        from setuptools import Extension
-    except ImportError:
-        from distutils.core import Extension
-else:
-    from distutils.core import Extension
+from distutils.core import Extension
 
 import Cython
 from Cython.Build.Inline import _get_build_extension
@@ -283,6 +274,8 @@ class StanModel:
             ('BOOST_NO_DECLTYPE', None),
             ('BOOST_DISABLE_ASSERTS', None),
         ]
+        
+        build_extension = _get_build_extension()
         # compile stan models with optimization (-O2)
         # (stanc is compiled without optimization (-O0) currently, see #33)
         if extra_compile_args is None:
@@ -292,7 +285,7 @@ class StanModel:
                 '-Wno-unused-function',
                 '-Wno-uninitialized',
             ]
-            if platform.platform().startswith('Win') and ccompiler.get_default_compiler() == 'msvc':
+            if platform.platform().startswith('Win') and build_extension.compiler == 'msvc':
                 extra_compile_args = ['/EHsc', '-DBOOST_DATE_TIME_NO_LIB']
 
         distutils.log.set_verbosity(verbose)
@@ -304,7 +297,7 @@ class StanModel:
                               extra_compile_args=extra_compile_args)
 
         cython_include_dirs = ['.', pystan_dir]
-        build_extension = _get_build_extension()
+        
         build_extension.extensions = cythonize([extension],
                                                include_path=cython_include_dirs,
                                                quiet=not verbose)

--- a/pystan/model.py
+++ b/pystan/model.py
@@ -285,7 +285,7 @@ class StanModel:
                 '-Wno-unused-function',
                 '-Wno-uninitialized',
             ]
-            if platform.platform().startswith('Win') and build_extension.compiler == 'msvc':
+            if platform.platform().startswith('Win') and build_extension.compiler in (None, 'msvc'):
                 extra_compile_args = ['/EHsc', '-DBOOST_DATE_TIME_NO_LIB']
 
         distutils.log.set_verbosity(verbose)

--- a/pystan/model.py
+++ b/pystan/model.py
@@ -143,7 +143,7 @@ class StanModel:
     verbose : boolean, False by default
         Indicates whether intermediate output should be piped to the console.
         This output may be useful for debugging.
-    
+
     kwargs : keyword arguments
         Additional arguments passed to `stanc`.
 
@@ -283,7 +283,6 @@ class StanModel:
             ('BOOST_NO_DECLTYPE', None),
             ('BOOST_DISABLE_ASSERTS', None),
         ]
-        
         # compile stan models with optimization (-O2)
         # (stanc is compiled without optimization (-O0) currently, see #33)
         if extra_compile_args is None:

--- a/setup.py
+++ b/setup.py
@@ -118,7 +118,7 @@ extra_compile_args = [
 
 if platform.platform().startswith('Win'):
     from Cython.Build.Inline import _get_build_extension
-    if _get_build_extension().compiler == 'msvc':
+    if _get_build_extension().compiler in (None, 'msvc'):
         extra_compile_args = [
             '/EHsc',
             '-DBOOST_DATE_TIME_NO_LIB',

--- a/setup.py
+++ b/setup.py
@@ -117,10 +117,12 @@ extra_compile_args = [
 ]
 
 if platform.platform().startswith('Win'):
-    extra_compile_args = [
-        '/EHsc',
-        '-DBOOST_DATE_TIME_NO_LIB',
-    ]
+    from Cython.Build.Inline import _get_build_extension
+    if _get_build_extension().compiler == 'msvc':
+        extra_compile_args = [
+            '/EHsc',
+            '-DBOOST_DATE_TIME_NO_LIB',
+        ]
 
 
 stanc_sources = [


### PR DESCRIPTION
Add msvc 2017 support by importing from `setuptools`. Needs `setuptools >= 34.4.0`.

Add compiler keyword (default None). User can choose mingw32, gcc / msvc.

On windows, check with subprocess (quietly) if gcc is installed on the system. If found, use it else use 'msvc'.

#### Summary:

Update model.py to support gcc on Windows.
Also update for msvc 2017 (setuptools).

See #364
#### Intended Effect:

Support gcc (MSYS2)

#### How to Verify:

Run on Windows with supported gcc compiler (MSYS2)

#### Side Effects:

Automatically detect if gcc installed with `subprocess`

#### Documentation:

Needs to be updated.

#### Reviewer Suggestions: 

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: GPLv3 (http://opensource.org/licenses/GPL-3.0)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
