### PR TITLE
DOC: add reminder to use pickle.HIGHEST_VERSION

### DIFF
--- a/doc/differences_pystan_rstan.rst
+++ b/doc/differences_pystan_rstan.rst
@@ -66,15 +66,15 @@ Python:
     fit = model.sampling(data=data)
 
     with open('model.pkl', 'wb') as f:
-        pickle.dump(model, f)
+        pickle.dump(model, f, protocol=pickle.HIGHEST_PROTOCOL)
 
     # load it at some future point
-
     with open('model.pkl', 'rb') as f:
         model = pickle.load(f)
 
     # run with different data
     fit = model.sampling(data=dict(N=5, y=[1, 1, 0, 1, 0]))
+
 
 R:
 
@@ -86,3 +86,7 @@ R:
     save(model, file='model.rdata')
 
 See also :ref:`avoiding-recompilation`.
+
+If you are saving a large amount of data with ``pickle.dump``, be sure to use
+the highest protocol version available. Earlier versions are limited in the
+amount of data they can save in a single file.


### PR DESCRIPTION
Earlier protocol versions of pickle are limited in the amount
of data they can serialize into a single file.

Closes #197

#### Summary:

#### Intended Effect:

#### How to Verify:

#### Side Effects:

#### Documentation:

#### Reviewer Suggestions: 

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: GPLv3 (http://opensource.org/licenses/GPL-3.0)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
