### PR TITLE
tests: drop testing python 3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,11 +14,9 @@ compiler:
   - gcc
 env:
   - TRAVIS_PYTHON_VERSION=2.7 TESTS_EXCLUDE_RE='^test_[a-p].*\.py'
-  - TRAVIS_PYTHON_VERSION=3.4 TESTS_EXCLUDE_RE='^test_[a-p].*\.py'
   - TRAVIS_PYTHON_VERSION=3.5 TESTS_EXCLUDE_RE='^test_[a-p].*\.py'
   - TRAVIS_PYTHON_VERSION=3.6 TESTS_EXCLUDE_RE='^test_[a-p].*\.py'
   - TRAVIS_PYTHON_VERSION=2.7 TESTS_EXCLUDE_RE='^test_[^a-p].*\.py'
-  - TRAVIS_PYTHON_VERSION=3.4 TESTS_EXCLUDE_RE='^test_[^a-p].*\.py'
   - TRAVIS_PYTHON_VERSION=3.5 TESTS_EXCLUDE_RE='^test_[^a-p].*\.py'
   - TRAVIS_PYTHON_VERSION=3.6 TESTS_EXCLUDE_RE='^test_[^a-p].*\.py'
 notifications:


### PR DESCRIPTION
Title says it all. Python 3.4 should work fine but it is no longer tested/supported. Dropping support is not unusual, I've observed a variety of packages dropping official Python 3.4 support.