### PR TITLE
Add option to `.extract`: odict with pars when permuted=False

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -40,7 +40,7 @@ a number of methods.
 
       This is currently an alias for the `traceplot` method.
 
-   .. py:method:: extract(pars=None, permuted=True, inc_warmup=False)
+   .. py:method:: extract(pars=None, permuted=True, inc_warmup=False, dtypes=None)
 
       Extract samples in different forms for different parameters.
 
@@ -54,6 +54,10 @@ a number of methods.
       inc_warmup : bool
          If True, warmup samples are kept; otherwise they are discarded. If
          `permuted` is True, `inc_warmup` is ignored.
+      dtypes : dict
+         datatype of parameter(s).
+         If nothing is passed, np.float will be used for all parameters.
+
 
       Returns
 
@@ -61,11 +65,71 @@ a number of methods.
       If `permuted` is True, return dictionary with samples for each
       parameter (or other quantity) named in `pars`.
 
-      If `permuted` is False, an array is returned. The first dimension of
+      If `permuted` is False and `pars` is None, an array is returned. The first dimension of
       the array is for the iterations; the second for the number of chains;
       the third for the parameters. Vectors and arrays are expanded to one
       parameter (a scalar) per cell, with names indicating the third dimension.
       Parameters are listed in the same order as `model_pars` and `flatnames`.
+
+      If `permuted` is False and `pars` is not None, return dictionary with samples for each
+      parameter (or other quantity) named in `pars`. The first dimension of
+      the sample array is for the iterations; the second for the number of chains;
+      the rest for the parameters. Parameters are listed in the same order as `pars`.
+
+   .. py:method:: stansummary(pars=None, probs=(0.025, 0.25, 0.5, 0.75, 0.975), digits_summary=2)
+   
+      Summary statistic table.
+      Parameters
+      ----------
+      pars : str or sequence of str, optional
+         Parameter names. By default use all parameters
+      probs : sequence of float, optional
+         Quantiles. By default, (0.025, 0.25, 0.5, 0.75, 0.975)
+      digits_summary : int, optional
+         Number of significant digits. By default, 2
+      Returns
+      -------
+      summary : string
+         Table includes mean, se_mean, sd, probs_0, ..., probs_n, n_eff and Rhat.
+      Examples
+      --------
+      >>> model_code = 'parameters {real y;} model {y ~ normal(0,1);}'  
+      >>> m = StanModel(model_code=model_code, model_name="example_model")  
+      >>> fit = m.sampling()  
+      >>> print(fit.stansummary())  
+      Inference for Stan model: example_model.  
+      4 chains, each with iter=2000; warmup=1000; thin=1;  
+      post-warmup draws per chain=1000, total post-warmup draws=4000.  
+             mean se_mean     sd   2.5%    25%    50%    75%  97.5%  n_eff   Rhat  
+      y      0.01    0.03    1.0  -2.01  -0.68   0.02   0.72   1.97   1330    1.0  
+      lp__   -0.5    0.02   0.68  -2.44  -0.66  -0.24  -0.05-5.5e-4   1555    1.0  
+      Samples were drawn using NUTS at Thu Aug 17 00:52:25 2017.  
+      For each parameter, n_eff is a crude measure of effective sample size,  
+      and Rhat is the potential scale reduction factor on split chains (at  
+      convergence, Rhat=1).
+
+   .. py:method:: summary(pars=None, probs=None)
+      
+      Summarize samples (compute mean, SD, quantiles) in all chains.
+      REF: stanfit-class.R summary method
+      Parameters
+      ----------
+      fit : StanFit4Model object
+      pars : str or sequence of str, optional
+         Parameter names. By default use all parameters
+      probs : sequence of float, optional
+         Quantiles. By default, (0.025, 0.25, 0.5, 0.75, 0.975)
+      Returns
+      -------
+      summaries : OrderedDict of array
+         Array indexed by 'summary' has dimensions (num_params, num_statistics).
+         Parameters are unraveled in *row-major order*. Statistics include: mean,
+         se_mean, sd, probs_0, ..., probs_n, n_eff, and Rhat. Array indexed by
+         'c_summary' breaks down the statistics by chain and has dimensions
+         (num_params, num_statistics_c_summary, num_chains). Statistics for
+         `c_summary` are the same as for `summary` with the exception that
+         se_mean, n_eff, and Rhat are absent. Row names and column names are
+         also included in the OrderedDict.
 
    .. py:method:: log_prob(upar, adjust_transform=True, gradient=False)
 
@@ -146,8 +210,12 @@ a number of methods.
           if parameters of interest include non-scalar parameters. An additional
           column for mean lp__ is also included.
 
+   .. py:method:: constrain_pars(np.ndarray[double, ndim=1, mode="c"] upar not None)
+      
+      Transform parameters from unconstrained space to defined support
+   
    .. py:method:: unconstrain_pars(par)
-
+       
       Transform parameters from defined support to unconstrained space
 
    .. py:method:: get_seed()
@@ -155,3 +223,7 @@ a number of methods.
    .. py:method:: get_inits()
 
    .. py:method:: get_stancode()
+   
+   .. py:property:: flatnames
+   
+   

--- a/pystan/stanfit4model.pyx
+++ b/pystan/stanfit4model.pyx
@@ -551,19 +551,25 @@ cdef class StanFit4Model:
         If `permuted` is True, return dictionary with samples for each
         parameter (or other quantity) named in `pars`.
 
-        If `permuted` is False, an array is returned. The first dimension of
+        If `permuted` is False and `pars` is None, an array is returned. The first dimension of
         the array is for the iterations; the second for the number of chains;
         the third for the parameters. Vectors and arrays are expanded to one
         parameter (a scalar) per cell, with names indicating the third dimension.
         Parameters are listed in the same order as `model_pars` and `flatnames`.
+        
+        If `permuted` is False and `pars` is not None, return dictionary with samples for each
+        parameter (or other quantity) named in `pars`. The first dimension of
+        the sample array is for the iterations; the second for the number of chains;
+        the rest for the parameters. Parameters are listed in the same order as `pars`.
 
         """
         self._verify_has_samples()
         if inc_warmup is True and permuted is True:
             logging.warning("`inc_warmup` ignored when `permuted` is True.")
-        if dtypes is None and permuted is False:
-            logging.warning("`dtypes` ignored when `permuted` is False.")
+        if (dtypes is not None) and (permuted is False) and (pars is None):
+            logging.warning("`dtypes` ignored when `permuted` is False and `pars` is None")
 
+        pars_original = pars
         if pars is None:
             pars = self.sim['pars_oi']
         elif isinstance(pars, string_types):
@@ -601,7 +607,33 @@ cdef class StanFit4Model:
                 extracted[par] = extracted[par].reshape(newdim, order='F')
                 # squeeze dim for scalar params, e.g., (4000,1) into (4000,)
                 if len(newdim) == 2 and newdim[1] == 1:
-                   extracted[par] = np.squeeze(extracted[par])
+                    extracted[par] = np.squeeze(extracted[par])
+        elif pars_original is not None:
+            n_chains = self.sim['chains']
+            extracted = collections.OrderedDict()
+            for par in pars:
+                extracted_par = []
+                for n in tidx[par]:
+                    chains = pystan.misc._get_samples(n, self.sim, inc_warmup)
+                    n_save = self.sim['n_save'][0]
+                    if not inc_warmup:
+                        n_save = n_save - self.sim['warmup2'][0]
+                    samples = np.column_stack(chains)
+                    extracted_par.append(samples[:, :, np.newaxis])
+                extracted_par = np.dstack(extracted_par)
+                if par in dtypes.keys():
+                    extracted_par = extracted_par.astype(dtypes[par])
+                extracted[par] = extracted_par
+                par_idx = self.sim['pars_oi'].index(par)
+                par_dim = self.sim['dims_oi'][par_idx]
+                # scalars have dim [], otherwise as one would expect
+                par_dim = [1] if par_dim == [] else par_dim
+                newdim = [n_save, n_chains] + par_dim
+                # order='F' means column-major order
+                extracted[par] = extracted[par].reshape(newdim, order='F')
+                # squeeze dim for scalar params, e.g., (1000,4,1) into (1000,4)
+                if len(newdim) == 3 and newdim[2] == 1:
+                    extracted[par] = np.squeeze(extracted[par])
         else:
             extracted = []
             for n in range(len(self.sim['fnames_oi'])):

--- a/pystan/stanfit4model.pyx
+++ b/pystan/stanfit4model.pyx
@@ -668,7 +668,6 @@ cdef class StanFit4Model:
 
         Parameters
         ----------
-        fit : StanFit4Model object
         pars : str or sequence of str, optional
             Parameter names. By default use all parameters
         probs : sequence of float, optional
@@ -702,6 +701,26 @@ cdef class StanFit4Model:
         return pystan.misc.stansummary(fit=self, pars=pars, probs=probs, digits_summary=digits_summary)
     
     def summary(self, pars=None, probs=None):
+        """Summarize samples (compute mean, SD, quantiles) in all chains.
+        REF: stanfit-class.R summary method
+        Parameters
+        ----------
+        pars : str or sequence of str, optional
+            Parameter names. By default use all parameters
+        probs : sequence of float, optional
+            Quantiles. By default, (0.025, 0.25, 0.5, 0.75, 0.975)
+        Returns
+        -------
+        summaries : OrderedDict of array
+            Array indexed by 'summary' has dimensions (num_params, num_statistics).
+            Parameters are unraveled in *row-major order*. Statistics include: mean,
+            se_mean, sd, probs_0, ..., probs_n, n_eff, and Rhat. Array indexed by
+            'c_summary' breaks down the statistics by chain and has dimensions
+            (num_params, num_statistics_c_summary, num_chains). Statistics for
+            `c_summary` are the same as for `summary` with the exception that
+            se_mean, n_eff, and Rhat are absent. Row names and column names are
+            also included in the OrderedDict.
+        """
         return pystan.misc._summary(self, pars, probs)
 
     def log_prob(self, upar, adjust_transform=True, gradient=False):

--- a/pystan/stanfit4model.pyx
+++ b/pystan/stanfit4model.pyx
@@ -566,7 +566,7 @@ cdef class StanFit4Model:
         self._verify_has_samples()
         if inc_warmup is True and permuted is True:
             logging.warning("`inc_warmup` ignored when `permuted` is True.")
-        if (dtypes is not None) and (permuted is False) and (pars is None):
+        if dtypes is not None and permuted is False and pars is None:
             logging.warning("`dtypes` ignored when `permuted` is False and `pars` is None")
 
         pars_original = pars

--- a/pystan/tests/test_basic.py
+++ b/pystan/tests/test_basic.py
@@ -117,8 +117,8 @@ class TestBernoulli(unittest.TestCase):
         assert 0.1 < np.mean(extr['theta']) < 0.4
         assert 0.01 < np.var(extr['theta']) < 0.02
         extr = fit.extract('theta', permuted=False)
-        assert extr.shape == (1000, 4, 2)
-        assert 0.1 < np.mean(extr[:, 0, 0]) < 0.4
+        assert extr['theta'].shape == (1000, 4)
+        assert 0.1 < np.mean(extr['theta'][:, 0]) < 0.4
 
     def test_bernoulli_random_seed_consistency(self):
         thetas = []

--- a/pystan/tests/test_extract.py
+++ b/pystan/tests/test_extract.py
@@ -67,6 +67,13 @@ class TestExtract(unittest.TestCase):
         self.assertEqual(ss['beta'].shape, (num_samples, 4, 2))
         self.assertTrue((~np.isnan(ss['beta'])).all())
         
+    def test_extract_permuted_false_inc_warmup(self):
+        fit = self.fit
+        ss = fit.extract(inc_warmup=True, permuted=False)
+        num_samples = fit.sim['iter']
+        self.assertEqual(ss.shape, (num_samples, 4, 9))
+        self.assertTrue((~np.isnan(ss)).all())
+    
     def test_extract_thin(self):
         sm = self.sm
         fit = sm.sampling(chains=4, iter=2000, thin=2)

--- a/pystan/tests/test_extract.py
+++ b/pystan/tests/test_extract.py
@@ -53,13 +53,20 @@ class TestExtract(unittest.TestCase):
         self.assertEqual(ss.shape, (num_samples, 4, 9))
         self.assertTrue((~np.isnan(ss)).all())
 
-    def test_extract_permuted_false_inc_warmup(self):
+    def test_extract_permuted_false_pars(self):
         fit = self.fit
-        ss = fit.extract(inc_warmup=True, permuted=False)
-        num_samples = fit.sim['iter']
-        self.assertEqual(ss.shape, (num_samples, 4, 9))
-        self.assertTrue((~np.isnan(ss)).all())
+        ss = fit.extract(pars=['beta'], permuted=False)
+        num_samples = fit.sim['iter'] - fit.sim['warmup']
+        self.assertEqual(ss['beta'].shape, (num_samples, 4, 2))
+        self.assertTrue((~np.isnan(ss['beta'])).all())
 
+    def test_extract_permuted_false_pars_inc_warmup(self):
+        fit = self.fit
+        ss = fit.extract(pars=['beta'], inc_warmup=True, permuted=False)
+        num_samples = fit.sim['iter']
+        self.assertEqual(ss['beta'].shape, (num_samples, 4, 2))
+        self.assertTrue((~np.isnan(ss['beta'])).all())
+        
     def test_extract_thin(self):
         sm = self.sm
         fit = sm.sampling(chains=4, iter=2000, thin=2)
@@ -96,3 +103,15 @@ class TestExtract(unittest.TestCase):
         self.assertEqual(alpha.dtype, np.dtype(np.int))
         self.assertEqual(beta.dtype, np.dtype(np.int))
         self.assertEqual(lp__.dtype, np.dtype(np.float))
+        
+    def test_extract_dtype_permuted_false(self):
+        dtypes = {"alpha": np.int, "beta": np.int}
+        pars = ['alpha', 'beta', 'lp__']
+        ss = self.fit.extract(pars=pars, dtypes = dtypes, permuted=False)
+        alpha = ss['alpha']
+        beta = ss['beta']
+        lp__ = ss['lp__']
+        self.assertEqual(alpha.dtype, np.dtype(np.int))
+        self.assertEqual(beta.dtype, np.dtype(np.int))
+        self.assertEqual(lp__.dtype, np.dtype(np.float))
+

--- a/pystan/tests/test_stan_file_io.py
+++ b/pystan/tests/test_stan_file_io.py
@@ -73,7 +73,7 @@ class TestStanFileIO(unittest.TestCase):
         assert 0.1 < np.mean(extr['theta']) < 0.4
         assert 0.01 < np.var(extr['theta']) < 0.02
         extr = fit.extract('theta', permuted=False)
-        assert extr.shape == (1000, 4, 2)
-        assert 0.1 < np.mean(extr[:, 0, 0]) < 0.4
+        assert extr['theta'].shape == (1000, 4)
+        assert 0.1 < np.mean(extr['theta'][:, 0]) < 0.4
 
         os.remove(temp_fn)

--- a/pystan/tests/test_stan_file_io.py
+++ b/pystan/tests/test_stan_file_io.py
@@ -52,8 +52,8 @@ class TestStanFileIO(unittest.TestCase):
         assert 0.1 < np.mean(extr['theta']) < 0.4
         assert 0.01 < np.var(extr['theta']) < 0.02
         extr = fit.extract('theta', permuted=False)
-        assert extr.shape == (1000, 4, 2)
-        assert 0.1 < np.mean(extr[:, 0, 0]) < 0.4
+        assert extr['theta'].shape == (1000, 4)
+        assert 0.1 < np.mean(extr['theta'][:, 0]) < 0.4
 
         fit = stan(file=temp_fn, data=bernoulli_data)
         extr = fit.extract(permuted=True)


### PR DESCRIPTION
#### Summary:

Add option to extract specific parameters with `permuted=False`. 
This will return an odict with array shape = (n_save, chains, *(dims)).

Also fixed warning: `dtypes is None and permuted=False`--> `dtypes is not None and permuted=False and pars is None`

#### Intended Effect:

Extract specific pars keeping the chain order.
Makes setting up plots easier with huge number of parameters

#### How to Verify:

~~Tests~~ Tests added

#### Side Effects:

Silent bugs, where one uses `pars` with `permuted=False`

#### Documentation:

~~Needs updating~~ Updated

#### Reviewer Suggestions: 

@ariddell 

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Ari Hartikainen

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: GPLv3 (http://opensource.org/licenses/GPL-3.0)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
