### PR TITLE
Output samples to pandas dataframe

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -226,4 +226,28 @@ a number of methods.
    
    .. py:property:: flatnames
    
-   
+   .. py:method:: to_dataframe(pars=None, permuted=True, dtypes=None, inc_warmup=False, diagnostics=True)
+
+      Extract samples as a pandas datafriame for different parameters.
+
+      Parameters
+      ----------
+      pars : {str, sequence of str}
+         parameter (or quantile) name(s). If `permuted` is False,
+         `pars` is ignored.
+      permuted : bool
+         If True, returned samples are permuted. All chains are
+         merged and warmup samples are discarded.
+      dtypes : dict
+         datatype of parameter(s).
+         If nothing is passed, np.float will be used for all parameters.
+      inc_warmup : bool
+         If True, warmup samples are kept; otherwise they are
+         discarded. If `permuted` is True, `inc_warmup` is ignored.
+      diagnostics : bool
+         If True, include MCMC diagnostics in dataframe.
+         If `permuted` is True, `diagnostics` is ignored.
+
+      Returns
+      -------
+      df : pandas dataframe

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -40,7 +40,7 @@ a number of methods.
 
       This is currently an alias for the `traceplot` method.
 
-   .. py:method:: extract(pars=None, permuted=True, inc_warmup=False)
+   .. py:method:: extract(pars=None, permuted=True, inc_warmup=False, dtypes=None)
 
       Extract samples in different forms for different parameters.
 
@@ -54,6 +54,10 @@ a number of methods.
       inc_warmup : bool
          If True, warmup samples are kept; otherwise they are discarded. If
          `permuted` is True, `inc_warmup` is ignored.
+      dtypes : dict
+         datatype of parameter(s).
+         If nothing is passed, np.float will be used for all parameters.
+
 
       Returns
 
@@ -61,11 +65,71 @@ a number of methods.
       If `permuted` is True, return dictionary with samples for each
       parameter (or other quantity) named in `pars`.
 
-      If `permuted` is False, an array is returned. The first dimension of
+      If `permuted` is False and `pars` is None, an array is returned. The first dimension of
       the array is for the iterations; the second for the number of chains;
       the third for the parameters. Vectors and arrays are expanded to one
       parameter (a scalar) per cell, with names indicating the third dimension.
       Parameters are listed in the same order as `model_pars` and `flatnames`.
+
+      If `permuted` is False and `pars` is not None, return dictionary with samples for each
+      parameter (or other quantity) named in `pars`. The first dimension of
+      the sample array is for the iterations; the second for the number of chains;
+      the rest for the parameters. Parameters are listed in the same order as `pars`.
+
+   .. py:method:: stansummary(pars=None, probs=(0.025, 0.25, 0.5, 0.75, 0.975), digits_summary=2)
+   
+      Summary statistic table.
+      Parameters
+      ----------
+      pars : str or sequence of str, optional
+         Parameter names. By default use all parameters
+      probs : sequence of float, optional
+         Quantiles. By default, (0.025, 0.25, 0.5, 0.75, 0.975)
+      digits_summary : int, optional
+         Number of significant digits. By default, 2
+      Returns
+      -------
+      summary : string
+         Table includes mean, se_mean, sd, probs_0, ..., probs_n, n_eff and Rhat.
+      Examples
+      --------
+      >>> model_code = 'parameters {real y;} model {y ~ normal(0,1);}'  
+      >>> m = StanModel(model_code=model_code, model_name="example_model")  
+      >>> fit = m.sampling()  
+      >>> print(fit.stansummary())  
+      Inference for Stan model: example_model.  
+      4 chains, each with iter=2000; warmup=1000; thin=1;  
+      post-warmup draws per chain=1000, total post-warmup draws=4000.  
+             mean se_mean     sd   2.5%    25%    50%    75%  97.5%  n_eff   Rhat  
+      y      0.01    0.03    1.0  -2.01  -0.68   0.02   0.72   1.97   1330    1.0  
+      lp__   -0.5    0.02   0.68  -2.44  -0.66  -0.24  -0.05-5.5e-4   1555    1.0  
+      Samples were drawn using NUTS at Thu Aug 17 00:52:25 2017.  
+      For each parameter, n_eff is a crude measure of effective sample size,  
+      and Rhat is the potential scale reduction factor on split chains (at  
+      convergence, Rhat=1).
+
+   .. py:method:: summary(pars=None, probs=None)
+      
+      Summarize samples (compute mean, SD, quantiles) in all chains.
+      REF: stanfit-class.R summary method
+      Parameters
+      ----------
+      fit : StanFit4Model object
+      pars : str or sequence of str, optional
+         Parameter names. By default use all parameters
+      probs : sequence of float, optional
+         Quantiles. By default, (0.025, 0.25, 0.5, 0.75, 0.975)
+      Returns
+      -------
+      summaries : OrderedDict of array
+         Array indexed by 'summary' has dimensions (num_params, num_statistics).
+         Parameters are unraveled in *row-major order*. Statistics include: mean,
+         se_mean, sd, probs_0, ..., probs_n, n_eff, and Rhat. Array indexed by
+         'c_summary' breaks down the statistics by chain and has dimensions
+         (num_params, num_statistics_c_summary, num_chains). Statistics for
+         `c_summary` are the same as for `summary` with the exception that
+         se_mean, n_eff, and Rhat are absent. Row names and column names are
+         also included in the OrderedDict.
 
    .. py:method:: log_prob(upar, adjust_transform=True, gradient=False)
 
@@ -146,8 +210,12 @@ a number of methods.
           if parameters of interest include non-scalar parameters. An additional
           column for mean lp__ is also included.
 
+   .. py:method:: constrain_pars(np.ndarray[double, ndim=1, mode="c"] upar not None)
+      
+      Transform parameters from unconstrained space to defined support
+   
    .. py:method:: unconstrain_pars(par)
-
+       
       Transform parameters from defined support to unconstrained space
 
    .. py:method:: get_seed()
@@ -155,3 +223,7 @@ a number of methods.
    .. py:method:: get_inits()
 
    .. py:method:: get_stancode()
+   
+   .. py:property:: flatnames
+   
+   

--- a/pystan/misc.py
+++ b/pystan/misc.py
@@ -53,7 +53,7 @@ logger = logging.getLogger('pystan')
 def stansummary(fit, pars=None, probs=(0.025, 0.25, 0.5, 0.75, 0.975), digits_summary=2):
     """
     Summary statistic table.
-    
+
     Parameters
     ----------
     fit : StanFit4Model object
@@ -68,7 +68,7 @@ def stansummary(fit, pars=None, probs=(0.025, 0.25, 0.5, 0.75, 0.975), digits_su
     -------
     summary : string
         Table includes mean, se_mean, sd, probs_0, ..., probs_n, n_eff and Rhat.
-    
+
     Examples
     --------
     >>> model_code = 'parameters {real y;} model {y ~ normal(0,1);}'
@@ -76,16 +76,16 @@ def stansummary(fit, pars=None, probs=(0.025, 0.25, 0.5, 0.75, 0.975), digits_su
     >>> fit = m.sampling()
     >>> print(stansummary(fit))
     Inference for Stan model: example_model.
-    4 chains, each with iter=2000; warmup=1000; thin=1; 
+    4 chains, each with iter=2000; warmup=1000; thin=1;
     post-warmup draws per chain=1000, total post-warmup draws=4000.
-    
+
            mean se_mean     sd   2.5%    25%    50%    75%  97.5%  n_eff   Rhat
     y      0.01    0.03    1.0  -2.01  -0.68   0.02   0.72   1.97   1330    1.0
     lp__   -0.5    0.02   0.68  -2.44  -0.66  -0.24  -0.05-5.5e-4   1555    1.0
-    
+
     Samples were drawn using NUTS at Thu Aug 17 00:52:25 2017.
     For each parameter, n_eff is a crude measure of effective sample size,
-    and Rhat is the potential scale reduction factor on split chains (at 
+    and Rhat is the potential scale reduction factor on split chains (at
     convergence, Rhat=1).
     """
     if fit.mode == 1:
@@ -1133,3 +1133,60 @@ def read_rdump(filename):
     for name, value in zip(names, values):
         d[name.strip()] = _rdump_value_to_numpy(value.strip())
     return d
+
+def to_dataframe(fit, pars=None, dtypes=None):
+    """Extract samples as a pandas dataframe for different parameters.
+
+    Parameters
+    ----------
+    pars : {str, sequence of str}
+       parameter (or quantile) name(s). If `permuted` is False,
+       `pars` is ignored.
+    dtypes : dict
+        datatype of parameter(s).
+        If nothing is passed, np.float will be used for all parameters.
+
+    Returns
+    -------
+    df : pandas dataframe
+
+    """
+    try:
+        import pandas as pd
+    except ImportError:
+        raise ImportError("Pandas module not found. You can install pandas with: pip install pandas")
+
+    fit._verify_has_samples()
+
+    if pars is None:
+        pars = fit.sim['pars_oi']
+    elif isinstance(pars, string_types):
+        pars = [pars]
+    pars = pystan.misc._remove_empty_pars(pars, fit.sim['pars_oi'], fit.sim['dims_oi'])
+    if dtypes is None:
+        dtypes = {}
+
+    allpars = fit.sim['pars_oi'] + fit.sim['fnames_oi']
+    pystan.misc._check_pars(allpars, pars)
+
+    tidx = pystan.misc._pars_total_indexes(fit.sim['pars_oi'],
+                                           fit.sim['dims_oi'],
+                                           fit.sim['fnames_oi'],
+                                           pars)
+
+    n_kept = [s-w for s, w in zip(fit.sim['n_save'], fit.sim['warmup2'])]
+
+    df = pd.DataFrame(index = np.arange(np.sum(n_kept)))
+
+    for par in pars:
+        sss = [pystan.misc._get_kept_samples(p, fit.sim)
+               for p in tidx[par]]
+        ss = np.column_stack(sss)
+        if par in dtypes.keys():
+            ss = ss.astype(dtypes[par])
+        if ss.shape[1] == 1:
+            df[par] = ss
+        else:
+            for idx in np.arange(ss.shape[1]):
+                df[par + '_{}'.format(idx)] = ss[:,idx]
+    return df

--- a/pystan/misc.py
+++ b/pystan/misc.py
@@ -1217,18 +1217,13 @@ def to_dataframe(fit, pars=None, permuted=True, dtypes=None, inc_warmup=False, d
         df['chain'] =  (np.arange(1,chain_count)[:,np.newaxis]*np.ones((chain_count-1,n_save))).astype(int).flatten()
         df['chain_idx'] = np.tile(np.arange(1,n_save+1),(chain_count-1,1)).flatten()
         if diagnostics == True:
-            divergent = []
-            energy = []
-            treedepth = []
-
-            for n in range(0,chain_count-1):
-                divergent.append(fit.get_sampler_params()[n]['divergent__'][-n_save:].astype(bool))
-                energy.append(fit.get_sampler_params()[n]['energy__'][-n_save:].astype(float))
-                treedepth.append(fit.get_sampler_params()[n]['treedepth__'][-n_save:].astype(int))
-
-            df['divergent__'] = np.hstack(divergent)
-            df['energy__'] = np.hstack(energy)
-            df['treedepth__'] = np.hstack(treedepth)
+            diagnostic_type = {'divergent':bool,'energy':float,'treedepth':int,
+			                   'accept_stat':float, 'stepsize':float, 'n_leapfrog':int}
+            for diag, diag_dtype in diagnostic_type.items():
+                diag_list = []
+                for n in range(0,chain_count-1):
+                    diag_list.append(fit.get_sampler_params()[n][diag + '__'][-n_save:].astype(diag_dtype))
+                df[diag + '__'] = np.hstack(diag_list)
         
         for n in range(len(fit.sim['fnames_oi'])):
             par = fit.sim['fnames_oi'][n]

--- a/pystan/misc.py
+++ b/pystan/misc.py
@@ -1140,8 +1140,7 @@ def to_dataframe(fit, pars=None, dtypes=None):
     Parameters
     ----------
     pars : {str, sequence of str}
-       parameter (or quantile) name(s). If `permuted` is False,
-       `pars` is ignored.
+       parameter (or quantile) name(s). 
     dtypes : dict
         datatype of parameter(s).
         If nothing is passed, np.float will be used for all parameters.
@@ -1187,6 +1186,10 @@ def to_dataframe(fit, pars=None, dtypes=None):
         if ss.shape[1] == 1:
             df[par] = ss
         else:
+            par_flatnames = [
+            flatname for flatname in fit.flatnames if flatname.startswith(par)
+            ]
             for idx in np.arange(ss.shape[1]):
-                df[par + '_{}'.format(idx)] = ss[:,idx]
+                column_name = par_flatnames[idx].replace('[','_').replace(',','_').replace(']','')
+                df[column_name] = ss[:,idx]
     return df

--- a/pystan/misc.py
+++ b/pystan/misc.py
@@ -1134,7 +1134,7 @@ def read_rdump(filename):
         d[name.strip()] = _rdump_value_to_numpy(value.strip())
     return d
 
-def to_dataframe(fit, pars=None, permuted=True, dtypes=None, inc_warmup=False):
+def to_dataframe(fit, pars=None, permuted=True, dtypes=None, inc_warmup=False, diagnostics=True):
     """Extract samples as a pandas dataframe for different parameters.
 
     Parameters
@@ -1150,7 +1150,9 @@ def to_dataframe(fit, pars=None, permuted=True, dtypes=None, inc_warmup=False):
     inc_warmup : bool
        If True, warmup samples are kept; otherwise they are
        discarded. If `permuted` is True, `inc_warmup` is ignored.
-
+    diagnostics : bool
+	   If True, include MCMC diagnostics in dataframe.
+	   If `permuted` is True, `diagnostics` is ignored.
 
     Returns
     -------
@@ -1163,6 +1165,8 @@ def to_dataframe(fit, pars=None, permuted=True, dtypes=None, inc_warmup=False):
         raise ImportError("Pandas module not found. You can install pandas with: pip install pandas")
     if inc_warmup is True and permuted is True:
         logging.warning("`inc_warmup` ignored when `permuted` is True.")
+    if diagnostics is True and permuted is True:
+        logging.warning("`diagnostics` ignored when `permuted` is True.")
     if dtypes is not None and permuted is False and pars is None:
         logging.warning("`dtypes` ignored when `permuted` is False and `pars` is None")
 
@@ -1212,24 +1216,27 @@ def to_dataframe(fit, pars=None, permuted=True, dtypes=None, inc_warmup=False):
         chain_count = fit.sim['chains']+1
         df['chain'] =  (np.arange(1,chain_count)[:,np.newaxis]*np.ones((chain_count-1,n_save))).astype(int).flatten()
         df['chain_idx'] = np.tile(np.arange(1,n_save+1),(chain_count-1,1)).flatten()
-        divergent = []
-        energy = []
-        treedepth = []
+        if diagnostics == True:
+            divergent = []
+            energy = []
+            treedepth = []
 
-        for n in range(0,chain_count-1):
-            divergent.append(fit.get_sampler_params()[n]['divergent__'][-n_save:].astype(bool))
-            energy.append(fit.get_sampler_params()[n]['energy__'][-n_save:].astype(float))
-            treedepth.append(fit.get_sampler_params()[n]['treedepth__'][-n_save:].astype(int))
+            for n in range(0,chain_count-1):
+                divergent.append(fit.get_sampler_params()[n]['divergent__'][-n_save:].astype(bool))
+                energy.append(fit.get_sampler_params()[n]['energy__'][-n_save:].astype(float))
+                treedepth.append(fit.get_sampler_params()[n]['treedepth__'][-n_save:].astype(int))
 
-        df['divergent__'] = np.hstack(divergent)
-        df['energy__'] = np.hstack(energy)
-        df['treedepth__'] = np.hstack(treedepth)
-
+            df['divergent__'] = np.hstack(divergent)
+            df['energy__'] = np.hstack(energy)
+            df['treedepth__'] = np.hstack(treedepth)
+        
         for n in range(len(fit.sim['fnames_oi'])):
-            chains = pystan.misc._get_samples(n, fit.sim, inc_warmup)
-            samples = np.array(chains).T
-            column_name = fit.sim['fnames_oi'][n].replace('[','_').replace(',','_').replace(']','')
-            # Use Stan 1-based indexing for column name strings
-            column_name = ''.join([str(int(n)+1)  if n.isdigit() else n for n in column_name])
-            df[column_name] = samples.T.flatten()
+            par = fit.sim['fnames_oi'][n]
+            if (par in pars) or (par[:par.find('[')] in pars):
+                chains = pystan.misc._get_samples(n, fit.sim, inc_warmup)
+                samples = np.array(chains).T
+                column_name = fit.sim['fnames_oi'][n].replace('[','_').replace(',','_').replace(']','')
+                # Use Stan 1-based indexing for column name strings
+                column_name = ''.join([str(int(n)+1)  if n.isdigit() else n for n in column_name])
+                df[column_name] = samples.T.flatten()
     return df

--- a/pystan/misc.py
+++ b/pystan/misc.py
@@ -1216,8 +1216,17 @@ def to_dataframe(fit, pars=None, permuted=True, dtypes=None, inc_warmup=False, d
         chain_count = fit.sim['chains']+1
         df['chain'] =  (np.arange(1,chain_count)[:,np.newaxis]*np.ones((chain_count-1,n_save))).astype(int).flatten()
         df['chain_idx'] = np.tile(np.arange(1,n_save+1),(chain_count-1,1)).flatten()
+		# Specify whether row is from warmup, 0 means not in warmup
+        df['warmup'] = 0
+        # Modify this below if sample is from warmup
+        if inc_warmup:
+            for n in range(0,chain_count-1):
+                df.loc[
+                n*fit.sim['n_save'][n]:
+                n*fit.sim['n_save'][n]+fit.sim['warmup2'][n]-1,'warmup'
+                ] = 1 
         if diagnostics == True:
-            diagnostic_type = {'divergent':bool,'energy':float,'treedepth':int,
+            diagnostic_type = {'divergent':int,'energy':float,'treedepth':int,
 			                   'accept_stat':float, 'stepsize':float, 'n_leapfrog':int}
             for diag, diag_dtype in diagnostic_type.items():
                 diag_list = []

--- a/pystan/misc.py
+++ b/pystan/misc.py
@@ -1199,7 +1199,7 @@ def to_dataframe(fit, pars=None, permuted=True, dtypes=None, inc_warmup=False, d
             if par in dtypes.keys():
                 ss = ss.astype(dtypes[par])
             if ss.shape[1] == 1:
-                df[par] = ss
+                df[par] = ss[:,0]
             else:
                 par_flatnames = [
                 flatname for flatname in fit.flatnames if flatname.startswith(par)

--- a/pystan/stanfit4model.pyx
+++ b/pystan/stanfit4model.pyx
@@ -556,7 +556,7 @@ cdef class StanFit4Model:
         the third for the parameters. Vectors and arrays are expanded to one
         parameter (a scalar) per cell, with names indicating the third dimension.
         Parameters are listed in the same order as `model_pars` and `flatnames`.
-        
+
         If `permuted` is False and `pars` is not None, return dictionary with samples for each
         parameter (or other quantity) named in `pars`. The first dimension of
         the sample array is for the iterations; the second for the number of chains;
@@ -859,7 +859,7 @@ cdef class StanFit4Model:
     def get_stanmodel(self):
         return self.stanmodel
 
-    def to_dataframe(self, pars=None, dtypes=None):
+    def to_dataframe(self, pars=None, permuted=True, dtypes=None, inc_warmup=False):
         """Extract samples as a pandas dataframe for different parameters.
 
         Parameters
@@ -867,6 +867,12 @@ cdef class StanFit4Model:
         pars : {str, sequence of str}
            parameter (or quantile) name(s). If `permuted` is False,
            `pars` is ignored.
+        permuted : bool
+           If True, returned samples are permuted. All chains are
+           merged and warmup samples are discarded.
+        inc_warmup : bool
+           If True, warmup samples are kept; otherwise they are
+           discarded. If `permuted` is True, `inc_warmup` is ignored.
         dtypes : dict
             datatype of parameter(s).
             If nothing is passed, np.float will be used for all parameters.
@@ -876,7 +882,7 @@ cdef class StanFit4Model:
         df : pandas dataframe
 
         """
-        return pystan.misc.to_dataframe(self, pars, dtypes)
+        return pystan.misc.to_dataframe(self, pars, permuted, dtypes, inc_warmup)
 
 
     # FIXME: when this is a normal Python class one can use @property instead

--- a/pystan/stanfit4model.pyx
+++ b/pystan/stanfit4model.pyx
@@ -661,7 +661,7 @@ cdef class StanFit4Model:
     def __getitem__(self, key):
         extr = self.extract(pars=(key,))
         return extr[key]
-    
+
     def stansummary(self, pars=None, probs=(0.025, 0.25, 0.5, 0.75, 0.975), digits_summary=2):
         """
         Summary statistic table.
@@ -686,7 +686,7 @@ cdef class StanFit4Model:
         >>> fit = m.sampling()
         >>> print(fit.stansummary())
         Inference for Stan model: example_model.
-        4 chains, each with iter=2000; warmup=1000; thin=1; 
+        4 chains, each with iter=2000; warmup=1000; thin=1;
         post-warmup draws per chain=1000, total post-warmup draws=4000.
 
                mean se_mean     sd   2.5%    25%    50%    75%  97.5%  n_eff   Rhat
@@ -695,11 +695,11 @@ cdef class StanFit4Model:
 
         Samples were drawn using NUTS at Thu Aug 17 00:52:25 2017.
         For each parameter, n_eff is a crude measure of effective sample size,
-        and Rhat is the potential scale reduction factor on split chains (at 
+        and Rhat is the potential scale reduction factor on split chains (at
         convergence, Rhat=1).
         """
         return pystan.misc.stansummary(fit=self, pars=pars, probs=probs, digits_summary=digits_summary)
-    
+
     def summary(self, pars=None, probs=None):
         """Summarize samples (compute mean, SD, quantiles) in all chains.
         REF: stanfit-class.R summary method
@@ -859,6 +859,26 @@ cdef class StanFit4Model:
     def get_stanmodel(self):
         return self.stanmodel
 
+    def to_dataframe(self, pars=None, dtypes=None):
+        """Extract samples as a pandas dataframe for different parameters.
+
+        Parameters
+        ----------
+        pars : {str, sequence of str}
+           parameter (or quantile) name(s). If `permuted` is False,
+           `pars` is ignored.
+        dtypes : dict
+            datatype of parameter(s).
+            If nothing is passed, np.float will be used for all parameters.
+
+        Returns
+        -------
+        df : pandas dataframe
+
+        """
+        return pystan.misc.to_dataframe(self, pars, dtypes)
+
+
     # FIXME: when this is a normal Python class one can use @property instead
     # of this special Cython syntax.
     property flatnames:
@@ -870,6 +890,7 @@ cdef class StanFit4Model:
             names = [n.encode('ascii') for n in self.model_pars]
             get_all_flatnames(names, self.par_dims, fnames, col_major=True)
             return [n.decode('ascii') for n in fnames]
+
 
     # "private" Python methods
 

--- a/pystan/stanfit4model.pyx
+++ b/pystan/stanfit4model.pyx
@@ -859,7 +859,7 @@ cdef class StanFit4Model:
     def get_stanmodel(self):
         return self.stanmodel
 
-    def to_dataframe(self, pars=None, permuted=True, dtypes=None, inc_warmup=False):
+    def to_dataframe(self, pars=None, permuted=True, dtypes=None, inc_warmup=False, diagnostics=True):
         """Extract samples as a pandas dataframe for different parameters.
 
         Parameters
@@ -870,19 +870,22 @@ cdef class StanFit4Model:
         permuted : bool
            If True, returned samples are permuted. All chains are
            merged and warmup samples are discarded.
+        dtypes : dict
+		    datatype of parameter(s).
+			If nothing is passed, np.float will be used for all parameters.
         inc_warmup : bool
            If True, warmup samples are kept; otherwise they are
            discarded. If `permuted` is True, `inc_warmup` is ignored.
-        dtypes : dict
-            datatype of parameter(s).
-            If nothing is passed, np.float will be used for all parameters.
+        diagnostics : bool
+	       If True, include MCMC diagnostics in dataframe.
+           If `permuted` is True, `diagnostics` is ignored.
 
         Returns
         -------
         df : pandas dataframe
 
         """
-        return pystan.misc.to_dataframe(self, pars, permuted, dtypes, inc_warmup)
+        return pystan.misc.to_dataframe(fit=self, pars=pars, permuted=permuted, dtypes=dtypes, inc_warmup=inc_warmup, diagnostics=diagnostics)
 
 
     # FIXME: when this is a normal Python class one can use @property instead

--- a/pystan/tests/test_basic.py
+++ b/pystan/tests/test_basic.py
@@ -117,8 +117,8 @@ class TestBernoulli(unittest.TestCase):
         assert 0.1 < np.mean(extr['theta']) < 0.4
         assert 0.01 < np.var(extr['theta']) < 0.02
         extr = fit.extract('theta', permuted=False)
-        assert extr.shape == (1000, 4, 2)
-        assert 0.1 < np.mean(extr[:, 0, 0]) < 0.4
+        assert extr['theta'].shape == (1000, 4)
+        assert 0.1 < np.mean(extr['theta'][:, 0]) < 0.4
 
     def test_bernoulli_random_seed_consistency(self):
         thetas = []

--- a/pystan/tests/test_extract.py
+++ b/pystan/tests/test_extract.py
@@ -161,7 +161,7 @@ class TestExtract(unittest.TestCase):
         df = fit.to_dataframe(permuted=False)
         num_samples = fit.sim['iter'] - fit.sim['warmup']
         num_chains = fit.sim['chains']
-        self.assertEqual(df.shape, (num_samples*num_chains,17))
+        self.assertEqual(df.shape, (num_samples*num_chains,18))
         alpha_index = 0
         for jdx in range(3):
             for idx in range(2):
@@ -250,7 +250,7 @@ class TestExtract(unittest.TestCase):
         df = fit.to_dataframe(permuted=False,diagnostics=False)
         num_samples = fit.sim['iter'] - fit.sim['warmup']
         num_chains = fit.sim['chains']
-        self.assertEqual(df.shape, (num_samples*num_chains,11))
+        self.assertEqual(df.shape, (num_samples*num_chains,12))
         alpha_index = 0
         for jdx in range(3):
             for idx in range(2):
@@ -277,14 +277,14 @@ class TestExtract(unittest.TestCase):
                 df.chain_idx.values[n*num_samples:(n+1)*num_samples],
                 np.arange(1,num_samples +1,dtype=np.int)
                 )
-                
+
     def test_to_dataframe_permuted_false_pars(self):
         fit = self.fit
         ss = fit.extract(permuted=False)
         df = fit.to_dataframe(permuted=False,pars='alpha')
         num_samples = fit.sim['iter'] - fit.sim['warmup']
         num_chains = fit.sim['chains']
-        self.assertEqual(df.shape, (num_samples*num_chains,14))
+        self.assertEqual(df.shape, (num_samples*num_chains,15))
         alpha_index = 0
         for jdx in range(3):
             for idx in range(2):

--- a/pystan/tests/test_extract.py
+++ b/pystan/tests/test_extract.py
@@ -179,7 +179,7 @@ class TestExtract(unittest.TestCase):
                 )
             for n in range(1,num_chains+1):
                 assert_array_equal(df.loc[df.chain == n,'lp__'].values,ss[:,n-1,-1])
-        diagnostic_type = {'divergent':bool,'energy':float,'treedepth':int,
+        diagnostic_type = {'divergent':int,'energy':float,'treedepth':int,
 			                'accept_stat':float, 'stepsize':float, 'n_leapfrog':int}
         for n in range(num_chains):
             assert_array_equal(
@@ -220,8 +220,15 @@ class TestExtract(unittest.TestCase):
                 )
             for n in range(1,num_chains+1):
                 assert_array_equal(df.loc[df.chain == n,'lp__'].values,ss[:,n-1,-1])
-			
-        diagnostic_type = {'divergent':bool,'energy':float,'treedepth':int,
+                assert_array_equal(df.loc[
+                (n-1)*fit.sim['n_save'][n-1]:
+                (n-1)*fit.sim['n_save'][n-1]+fit.sim['warmup2'][n-1]-1,'warmup'].values,
+                np.ones(fit.sim['warmup2'][n-1]))
+                assert_array_equal(df.loc[
+                (n-1)*fit.sim['n_save'][n-1]+fit.sim['warmup2'][n-1]:
+                (n)*fit.sim['n_save'][n-1]-1,'warmup'].values,
+                np.zeros(fit.sim['warmup2'][n-1]))
+        diagnostic_type = {'divergent':int,'energy':float,'treedepth':int,
 			                'accept_stat':float, 'stepsize':float, 'n_leapfrog':int}
         for n in range(num_chains):
             assert_array_equal(
@@ -287,7 +294,7 @@ class TestExtract(unittest.TestCase):
                     df[name].loc[df.chain == n].values,ss[:,n-1,alpha_index]
                     )
                 alpha_index += 1
-        diagnostic_type = {'divergent':bool,'energy':float,'treedepth':int,
+        diagnostic_type = {'divergent':int,'energy':float,'treedepth':int,
 			                'accept_stat':float, 'stepsize':float, 'n_leapfrog':int}
         for n in range(num_chains):
             assert_array_equal(

--- a/pystan/tests/test_extract.py
+++ b/pystan/tests/test_extract.py
@@ -53,13 +53,27 @@ class TestExtract(unittest.TestCase):
         self.assertEqual(ss.shape, (num_samples, 4, 9))
         self.assertTrue((~np.isnan(ss)).all())
 
+    def test_extract_permuted_false_pars(self):
+        fit = self.fit
+        ss = fit.extract(pars=['beta'], permuted=False)
+        num_samples = fit.sim['iter'] - fit.sim['warmup']
+        self.assertEqual(ss['beta'].shape, (num_samples, 4, 2))
+        self.assertTrue((~np.isnan(ss['beta'])).all())
+
+    def test_extract_permuted_false_pars_inc_warmup(self):
+        fit = self.fit
+        ss = fit.extract(pars=['beta'], inc_warmup=True, permuted=False)
+        num_samples = fit.sim['iter']
+        self.assertEqual(ss['beta'].shape, (num_samples, 4, 2))
+        self.assertTrue((~np.isnan(ss['beta'])).all())
+        
     def test_extract_permuted_false_inc_warmup(self):
         fit = self.fit
         ss = fit.extract(inc_warmup=True, permuted=False)
         num_samples = fit.sim['iter']
         self.assertEqual(ss.shape, (num_samples, 4, 9))
         self.assertTrue((~np.isnan(ss)).all())
-
+    
     def test_extract_thin(self):
         sm = self.sm
         fit = sm.sampling(chains=4, iter=2000, thin=2)
@@ -96,3 +110,15 @@ class TestExtract(unittest.TestCase):
         self.assertEqual(alpha.dtype, np.dtype(np.int))
         self.assertEqual(beta.dtype, np.dtype(np.int))
         self.assertEqual(lp__.dtype, np.dtype(np.float))
+        
+    def test_extract_dtype_permuted_false(self):
+        dtypes = {"alpha": np.int, "beta": np.int}
+        pars = ['alpha', 'beta', 'lp__']
+        ss = self.fit.extract(pars=pars, dtypes = dtypes, permuted=False)
+        alpha = ss['alpha']
+        beta = ss['beta']
+        lp__ = ss['lp__']
+        self.assertEqual(alpha.dtype, np.dtype(np.int))
+        self.assertEqual(beta.dtype, np.dtype(np.int))
+        self.assertEqual(lp__.dtype, np.dtype(np.float))
+

--- a/pystan/tests/test_extract.py
+++ b/pystan/tests/test_extract.py
@@ -121,3 +121,38 @@ class TestExtract(unittest.TestCase):
         self.assertEqual(alpha.dtype, np.dtype(np.int))
         self.assertEqual(beta.dtype, np.dtype(np.int))
         self.assertEqual(lp__.dtype, np.dtype(np.float))
+
+  def test_to_dataframe(self):
+        ss = self.fit.extract(permuted=True)
+        alpha = ss['alpha']
+        beta = ss['beta']
+        lp__ = ss['lp__']
+        df = self.fit.to_dataframe()
+        self.assertEqual(df.shape, (4000,9))
+        for idx in range(2):
+            for jdx in range(3):
+                name = 'alpha_{}_{}'.format(idx,jdx)
+                assert_series_equal(df[name],pd.Series(alpha[:,idx,jdx],name=name))
+        for idx in range(2):
+            name = 'beta_{}'.format(idx)
+            assert_series_equal(df[name],pd.Series(beta[:,idx],name=name))
+        assert_series_equal(df['lp__'],pd.Series(lp__,name='lp__'))
+        ss = self.fit.extract(permuted=True)
+        alpha = ss['alpha']
+        beta = ss['beta']
+        lp__ = ss['lp__']
+        # Test pars argument
+        df = self.fit.to_dataframe(pars='alpha')
+        self.assertEqual(df.shape, (4000,6))
+        for idx in range(2):
+            for jdx in range(3):
+                name = 'alpha_{}_{}'.format(idx,jdx)
+                assert_series_equal(df[name],pd.Series(alpha[:,idx,jdx],name=name))
+        # Test pars and dtype argument
+        df = self.fit.to_dataframe(pars='alpha',dtypes = {'alpha':np.int})
+        alpha_int = ss['alpha'].astype(np.int)
+        self.assertEqual(df.shape, (4000,6))
+        for idx in range(2):
+            for jdx in range(3):
+                name = 'alpha_{}_{}'.format(idx,jdx)
+                assert_series_equal(df[name],pd.Series(alpha_int[:,idx,jdx],name=name))

--- a/pystan/tests/test_extract.py
+++ b/pystan/tests/test_extract.py
@@ -202,7 +202,7 @@ class TestExtract(unittest.TestCase):
         df = fit.to_dataframe(permuted=False,inc_warmup=True)
         num_samples = fit.sim['iter']
         num_chains = fit.sim['chains']
-        self.assertEqual(df.shape, (num_samples*num_chains,17))
+        self.assertEqual(df.shape, (num_samples*num_chains,18))
         alpha_index = 0
         for jdx in range(3):
             for idx in range(2):

--- a/pystan/tests/test_extract.py
+++ b/pystan/tests/test_extract.py
@@ -66,14 +66,14 @@ class TestExtract(unittest.TestCase):
         num_samples = fit.sim['iter']
         self.assertEqual(ss['beta'].shape, (num_samples, 4, 2))
         self.assertTrue((~np.isnan(ss['beta'])).all())
-        
+
     def test_extract_permuted_false_inc_warmup(self):
         fit = self.fit
         ss = fit.extract(inc_warmup=True, permuted=False)
         num_samples = fit.sim['iter']
         self.assertEqual(ss.shape, (num_samples, 4, 9))
         self.assertTrue((~np.isnan(ss)).all())
-    
+
     def test_extract_thin(self):
         sm = self.sm
         fit = sm.sampling(chains=4, iter=2000, thin=2)
@@ -110,7 +110,7 @@ class TestExtract(unittest.TestCase):
         self.assertEqual(alpha.dtype, np.dtype(np.int))
         self.assertEqual(beta.dtype, np.dtype(np.int))
         self.assertEqual(lp__.dtype, np.dtype(np.float))
-        
+
     def test_extract_dtype_permuted_false(self):
         dtypes = {"alpha": np.int, "beta": np.int}
         pars = ['alpha', 'beta', 'lp__']
@@ -121,4 +121,3 @@ class TestExtract(unittest.TestCase):
         self.assertEqual(alpha.dtype, np.dtype(np.int))
         self.assertEqual(beta.dtype, np.dtype(np.int))
         self.assertEqual(lp__.dtype, np.dtype(np.float))
-

--- a/pystan/tests/test_stan_file_io.py
+++ b/pystan/tests/test_stan_file_io.py
@@ -52,8 +52,8 @@ class TestStanFileIO(unittest.TestCase):
         assert 0.1 < np.mean(extr['theta']) < 0.4
         assert 0.01 < np.var(extr['theta']) < 0.02
         extr = fit.extract('theta', permuted=False)
-        assert extr.shape == (1000, 4, 2)
-        assert 0.1 < np.mean(extr[:, 0, 0]) < 0.4
+        assert extr['theta'].shape == (1000, 4)
+        assert 0.1 < np.mean(extr['theta'][:, 0]) < 0.4
 
         fit = stan(file=temp_fn, data=bernoulli_data)
         extr = fit.extract(permuted=True)
@@ -73,7 +73,7 @@ class TestStanFileIO(unittest.TestCase):
         assert 0.1 < np.mean(extr['theta']) < 0.4
         assert 0.01 < np.var(extr['theta']) < 0.02
         extr = fit.extract('theta', permuted=False)
-        assert extr.shape == (1000, 4, 2)
-        assert 0.1 < np.mean(extr[:, 0, 0]) < 0.4
+        assert extr['theta'].shape == (1000, 4)
+        assert 0.1 < np.mean(extr['theta'][:, 0]) < 0.4
 
         os.remove(temp_fn)


### PR DESCRIPTION
#### Summary:
Samples can be output as a pandas dataframe.  This can be done as a method on a fit object or equivalently as a function that takes fit as an argument.  

#### Intended Effect:
The samples are output as a dataframe with the sample number as the index.

#### How to Verify:
Once the model is fit (e.g. 8 schools) can run
```
df = pystan.misc.to_dataframe(fit)
```
or more simply
```
df = fit.to_dataframe()
```
Tests to follow once reviewer suggestions have been taken onboard.

#### Side Effects:
The dependence on pandas is through a try/except/raise statement.  If pandas isn't found it prints an error message explaining how to install pandas.  In some versions of the **iPython** shell the ImportError statement raises its own error with a message like:
```
AttributeError: 'ImportError' object has no attribute '_render_traceback_'
```
I think this is the same as this error flagged with ipython:https://github.com/ipython/ipython/issues/9978

If the command is run more than once then the error message appears as it was intended.  Hopefully, this will be be resolved in future versions of ipython.

#### Documentation:
To follow once reviewer suggestions have been taken onboard.

#### Reviewer Suggestions: 

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: GPLv3 (http://opensource.org/licenses/GPL-3.0)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
