### PR TITLE
Stop shuffling extracted samples

### DIFF
--- a/pystan/_misc.pyx
+++ b/pystan/_misc.pyx
@@ -9,7 +9,6 @@ cpdef get_kept_samples(int n, dict sim):
     """See documentation in misc.py"""
     cdef int i, j, num_chains, num_samples, num_warmup, ss_index, s_index
     cdef double[:] s, ss
-    cdef long[:] perm
     num_chains = sim['chains']
     nth_key = list(sim['samples'][0]['chains'].keys())[n]
 
@@ -19,11 +18,10 @@ cpdef get_kept_samples(int n, dict sim):
 
     ss = np.empty((num_samples - num_warmup) * num_chains)
     for i in range(num_chains):
-        perm = sim['permutation'][i]
         s = sim['samples'][i]['chains'][nth_key]
         for j in range(num_samples - num_warmup):
             ss_index = i * (num_samples - num_warmup) + j
-            s_index = num_warmup + perm[j]
+            s_index = num_warmup + j
             ss[ss_index] = s[s_index]
     return ss
 


### PR DESCRIPTION
#### Summary:
When calling `extract`, the default argument `permuted=True` returns a parameter-keyed dictionary of samples in shuffled order. When `permuted=False`, samples are in the order they were sampled in, but the result is not longer a `dict` object, so the samples are harder to retrieve for a desired parameter. Traceplots also call `extract` with default arguments, so it is impossible to detect autocorrelation in the samples just by looking at the plots. The plan for PyStan3 already seems to be getting rid of `extract(permuted=True)`, as discussed in this thread: https://github.com/stan-dev/rstan/issues/345.

#### Intended Effect:
Extract parameter samples in the same order they were sampled, rather than in permuted order, while leaving intact the ability to retrieve them through a `dict` object keyed by parameter names. This will make `permuted=True` just arrange samples into a `dict` rather than actually shuffling them ("permuted" might not be the right word to use anymore).

#### How to Verify:
Fit a model, then call `extract()` and `extract(permuted=False)`. The first result should be a `dict` keyed by parameter names with values containing the parameter samples after the warmup period. The latter should be an array with parameters in the same order as `flatnames`, optionally containing the warmup samples. Both the former and the latter should have the same samples in the same order after the warmup period for any given parameter.

#### Side Effects:
None

#### Documentation:
The current documentation at http://pystan.readthedocs.io/en/latest/api.html says samples will be permuted by calling `permuted=True`. It is not clear from the documentation how they were being permuted, and it will still not be clear that they will now be in the same order they were sampled in. It may make more sense to call this argument `return_dict` rather than `permuted`.

#### Reviewer Suggestions: 

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):
Revionics

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: GPLv3 (http://opensource.org/licenses/GPL-3.0)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)