### PR TITLE
1-based indexing

### DIFF
--- a/pystan/misc.py
+++ b/pystan/misc.py
@@ -1206,8 +1206,6 @@ def to_dataframe(fit, pars=None, permuted=True, dtypes=None, inc_warmup=False, d
                 ]
                 for idx in np.arange(ss.shape[1]):
                     column_name = par_flatnames[idx].replace('[','_').replace(',','_').replace(']','')
-                    # Use Stan 1-based indexing for column name strings
-                    column_name = ''.join([str(int(n)+1)  if n.isdigit() else n for n in column_name])
                     df[column_name] = ss[:,idx]
     else:
         n_save = fit.sim['n_save'][0]
@@ -1240,7 +1238,5 @@ def to_dataframe(fit, pars=None, permuted=True, dtypes=None, inc_warmup=False, d
                 chains = pystan.misc._get_samples(n, fit.sim, inc_warmup)
                 samples = np.array(chains).T
                 column_name = fit.sim['fnames_oi'][n].replace('[','_').replace(',','_').replace(']','')
-                # Use Stan 1-based indexing for column name strings
-                column_name = ''.join([str(int(n)+1)  if n.isdigit() else n for n in column_name])
                 df[column_name] = samples.T.flatten()
     return df

--- a/pystan/stan_fit.hpp
+++ b/pystan/stan_fit.hpp
@@ -609,7 +609,8 @@ namespace pystan {
       for (size_t i = 0; i < names.size(); ++i) {
         std::vector<std::string> i_names;
         // NOTE: col_major = true, first_is_one = true for PyStan (true for RStan)
-        get_flatnames(names[i], dims[i], i_names, col_major, true);
+        // first_is_one changed to true from false in PyStan 2.18
+	get_flatnames(names[i], dims[i], i_names, col_major, true);
         fnames.insert(fnames.end(), i_names.begin(), i_names.end());
       }
     }

--- a/pystan/stan_fit.hpp
+++ b/pystan/stan_fit.hpp
@@ -608,8 +608,8 @@ namespace pystan {
       fnames.clear();
       for (size_t i = 0; i < names.size(); ++i) {
         std::vector<std::string> i_names;
-        // NOTE: col_major = true, first_is_one = false for PyStan (true for RStan)
-        get_flatnames(names[i], dims[i], i_names, col_major, false);
+        // NOTE: col_major = true, first_is_one = true for PyStan (true for RStan)
+        get_flatnames(names[i], dims[i], i_names, col_major, true);
         fnames.insert(fnames.end(), i_names.begin(), i_names.end());
       }
     }


### PR DESCRIPTION
Start indexing with 1 for `fit.flatnames`.

#### Summary:

Starts indexing with 1.

#### Intended Effect:

Correct indices for `fit.summary` and `fit.stansummary`

#### How to Verify:

`print(fit)`

#### Side Effects:

Are these used other than naming parameters.

#### Documentation:

Needs to be checked.

#### Reviewer Suggestions: 

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): Ari Hartikainen

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: GPLv3 (http://opensource.org/licenses/GPL-3.0)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
