### PR TITLE
Issue #427: Integrate Betancourt's stan_utility functions into PyStan

### DIFF
--- a/pystan/__init__.py
+++ b/pystan/__init__.py
@@ -8,6 +8,7 @@ import logging
 
 from pystan.api import stanc, stan
 from pystan.misc import read_rdump, stan_rdump, stansummary
+from pystan.diagnostics import check_MCMC_diagnostics
 from pystan.model import StanModel
 from pystan.lookup import lookup
 

--- a/pystan/_chains.pyx
+++ b/pystan/_chains.pyx
@@ -82,6 +82,7 @@ cdef vector[double] autocovariance(dict sim, int k, int n):
     return acov
 
 
+@cython.cdivision(True)
 def effective_sample_size(dict sim, int n):
     """
     Return the effective sample size for the specified parameter

--- a/pystan/diagnostics.py
+++ b/pystan/diagnostics.py
@@ -6,24 +6,30 @@ import warnings
 # Diagnostics modified from Betancourt's stan_utility.py module
 
 def check_div(fit, verbose = True):
-    """Check transitions that ended with a divergence
+    """Check for transitions that ended with a divergence
 
-    This function returns True if there are no problems with divergent
-    transitions and False otherwise.
-    
-    Optional argument "verbose" is either a Boolean or an integral
-    value.
+    Parameters
+    ----------
+    fit : StanFit4Model object
+    verbose : bool or int, optional
+        If ``verbose`` is ``False`` or a nonpositive integer, no
+        diagnostic messages are printed, and only the return value of
+        the function conveys diagnostic information. If it is ``True``
+        (the default) or an integer greater than zero, then a
+        diagnostic message is printed only if there are divergent
+        transitions. If it is an integer greater than 1, then extra
+        diagnostic messages are printed.
 
-    If "verbose" is True (the default) or an integer greater than
-    zero, then a diagnostic message is printed only if there are
-    divergent transitions.
+    Returns
+    -------
+    bool
+        ``True`` if there are no problems with divergent transitions
+        and ``False`` otherwise.
 
-    If "verbose" is greater than 1, then extra diagnostic messages are
-    printed.
-
-    If "verbose" is False or zero, no diagnostic messages are
-    printed, and only the return value of the function conveys
-    diagnostic information.
+    Raises
+    ------
+    ValueError
+        If ``fit`` has no information about divergent transitions.
 
     """
 
@@ -66,25 +72,35 @@ def check_div(fit, verbose = True):
         
 
 def check_treedepth(fit, verbose = True):
-    """Check transitions that ended prematurely due to maximum tree depth limit
+    """Check for transitions that ended prematurely due to maximum tree
+    depth limit
 
-    This function returns True if there are no problems with tree
-    depth and False otherwise.
-    
-    Optional argument "verbose" is either a Boolean or an integral
-    value.
+    Parameters
+    ----------
+    fit : StanFit4Model object
+    verbose : bool or int, optional
+        If ``verbose`` is ``False`` or a nonpositive integer, no
+        diagnostic messages are printed, and only the return value of
+        the function conveys diagnostic information. If it is ``True``
+        (the default) or an integer greater than zero, then a
+        diagnostic message is printed only if there are transitions
+        that ended ended prematurely due to maximum tree depth
+        limit. If it is an integer greater than 1, then extra
+        diagnostic messages are printed.
 
-    If "verbose" is True (the default) or an integer greater than
-    zero, then a diagnostic message is printed only if there are
-    transitions that ended ended prematurely due to maximum tree depth
-    limit.
 
-    If "verbose" is greater than 1, then extra diagnostic messages are
-    printed.
+    Returns
+    -------
+    bool
+        ``True`` if there are no problems with tree depth and
+        ``False`` otherwise.
 
-    If "verbose" is False or zero, no diagnostic messages are
-    printed, and only the return value of the function conveys
-    diagnostic information.
+    Raises
+    ------
+    ValueError
+        If ``fit`` has no information about tree depth. This could
+        happen if ``fit`` was generated from a sampler other than
+        NUTS.
 
     """
 
@@ -122,22 +138,29 @@ def check_treedepth(fit, verbose = True):
 def check_energy(fit, verbose = True):
     """Checks the energy Bayesian fraction of missing information (E-BFMI)
 
-    This function returns True if there are no problems with E-BFMI
-    and False otherwise.
-    
-    Optional argument "verbose" is either a Boolean or an integral
-    value.
+    Parameters
+    ----------
+    fit : StanFit4Model object
+    verbose : bool or int, optional
+        If ``verbose`` is ``False`` or a nonpositive integer, no
+        diagnostic messages are printed, and only the return value of
+        the function conveys diagnostic information. If it is ``True``
+        (the default) or an integer greater than zero, then a
+        diagnostic message is printed only if there is low E-BFMI in
+        one or more chains. If it is an integer greater than 1, then
+        extra diagnostic messages are printed.
 
-    If "verbose" is True (the default) or an integer greater than
-    zero, then diagnostic messages are printed only if there is low
-    E-BFMI in one or more chains.
 
-    If "verbose" is greater than 1, then extra diagnostic messages are
-    printed.
+    Returns
+    -------
+    bool
+        ``True`` if there are no problems with E-BFMI and ``False``
+        otherwise.
 
-    If "verbose" is False or zero, no diagnostic messages are
-    printed, and only the return value of the function conveys
-    diagnostic information.
+    Raises
+    ------
+    ValueError
+        If ``fit`` has no information about E-BFMI.
 
     """
 
@@ -176,22 +199,31 @@ def check_energy(fit, verbose = True):
 def check_n_eff(fit, verbose = True):
     """Checks the effective sample size per iteration
 
-    This function returns True if there are no problems with effective
-    sample size.
-    
-    Optional argument "verbose" is either a Boolean or an integral
-    value.
+    Parameters
+    ----------
+    fit : StanFit4Model object
+    verbose : bool or int, optional
+        If ``verbose`` is ``False`` or a nonpositive integer, no
+        diagnostic messages are printed, and only the return value of
+        the function conveys diagnostic information. If it is ``True``
+        (the default) or an integer greater than zero, then a
+        diagnostic message is printed only if there are effective
+        sample sizes that appear pathologically low. If it is an
+        integer greater than 1, then extra diagnostic messages are
+        printed.
 
-    If "verbose" is True (the default) or an integer greater than
-    zero, then diagnostic messages are printed only if there are
-    effective sample sizes that appear pathologically low.
 
-    If "verbose" is greater than 1, then extra diagnostic messages are
-    printed.
+    Returns
+    -------
+    bool
+        ``True`` if there are no problems with effective sample size
+        and ``False`` otherwise.
 
-    If "verbose" is False or zero, no diagnostic messages are
-    printed, and only the return value of the function conveys
-    diagnostic information.
+    Raises
+    ------
+    ValueError
+        If the output of ``fit.summary()`` has no information about
+        effective sample size (i.e., n_eff).
 
     """
 
@@ -227,24 +259,32 @@ def check_n_eff(fit, verbose = True):
             print('n_eff / iter below 0.001 indicates that the effective sample size has likely been overestimated')
 
 def check_rhat(fit, verbose = True):
-    """Checks the potential scale reduction factors
+    """Checks the potential scale reduction factors, i.e., Rhat values
 
-    This function returns True if there are no problems with Rhat, the
-    potential scale reduction factor
-    
-    Optional argument "verbose" is either a Boolean or an integral
-    value.
+    Parameters
+    ----------
+    fit : StanFit4Model object
+    verbose : bool or int, optional
+        If ``verbose`` is ``False`` or a nonpositive integer, no
+        diagnostic messages are printed, and only the return value of
+        the function conveys diagnostic information. If it is ``True``
+        (the default) or an integer greater than zero, then a
+        diagnostic message is printed only if there are Rhat values
+        too far from 1. If ``verbose`` is an integer greater than 1,
+        then extra diagnostic messages are printed.
 
-    If "verbose" is True (the default) or an integer greater than
-    zero, then diagnostic messages are printed only if there are Rhat
-    values too far from 1.
 
-    If "verbose" is greater than 1, then extra diagnostic messages are
-    printed.
+    Returns
+    -------
+    bool
+        ``True`` if there are no problems with with Rhat and ``False``
+        otherwise.
 
-    If "verbose" is False or zero, no diagnostic messages are
-    printed, and only the return value of the function conveys
-    diagnostic information.
+    Raises
+    ------
+    ValueError
+        If the output of ``fit.summary()`` has no information about
+        Rhat.
 
     """
     
@@ -286,28 +326,28 @@ def check_rhat(fit, verbose = True):
 def check_MCMC_diagnostics(fit, verbose = True):
     """Checks all MCMC diagnostics
 
-    This function returns a dictionary where each key returns a
-    diagnostic check, and the value associated with each key is a
-    Boolean value that is True if the check passed and False
-    otherwise.
+    Parameters
+    ----------
+    fit : StanFit4Model object
+    verbose : bool or int, optional
+        If ``verbose`` is ``False`` or a nonpositive integer, no
+        diagnostic messages are printed, and only the return value of
+        the function conveys diagnostic information. If it is ``True``
+        (the default) or an integer greater than zero, then diagnostic
+        messages are printed only for diagnostic checks that fail. If
+        ``verbose`` is an integer greater than 1, then extra
+        diagnostic messages are printed.
 
-    Possible valid keys are 'n_eff', 'Rhat', 'divergence',
-    'treedepth', and 'energy', though which keys are available will
-    depend upon the sampling algorithm used.
-    
-    Optional argument "verbose" is either a Boolean or an integral
-    value.
 
-    If "verbose" is True (the default) or an integer greater than
-    zero, then diagnostic messages are printed only if there are Rhat
-    values too far from 1.
-
-    If "verbose" is greater than 1, then extra diagnostic messages are
-    printed.
-
-    If "verbose" is False or zero, no diagnostic messages are
-    printed, and only the return value of the function conveys
-    diagnostic information.
+    Returns
+    -------
+    out_dict : dict
+        A dictionary where each key is the name of a diagnostic check,
+        and the value associated with each key is a Boolean value that
+        is True if the check passed and False otherwise.  Possible
+        valid keys are 'n_eff', 'Rhat', 'divergence', 'treedepth', and
+        'energy', though which keys are available will depend upon the
+        sampling algorithm used.
 
     """
 
@@ -347,34 +387,3 @@ def check_MCMC_diagnostics(fit, verbose = True):
             print('Skipping check of E-BFMI (energy)')
 
     return out_dict
-
-def _by_chain(unpermuted_extraction):
-    num_chains = len(unpermuted_extraction[0])
-    result = [[] for _ in range(num_chains)]
-    for c in range(num_chains):
-        for i in range(len(unpermuted_extraction)):
-            result[c].append(unpermuted_extraction[i][c])
-    return numpy.array(result)
-
-def _shaped_ordered_params(fit):
-    ef = fit.extract(permuted=False, inc_warmup=False) # flattened, unpermuted, by (iteration, chain)
-    ef = _by_chain(ef)
-    ef = ef.reshape(-1, len(ef[0][0]))
-    ef = ef[:, 0:len(fit.flatnames)] # drop lp__
-    shaped = {}
-    idx = 0
-    for dim, param_name in zip(fit.par_dims, fit.extract().keys()):
-        length = int(numpy.prod(dim))
-        shaped[param_name] = ef[:,idx:idx + length]
-        shaped[param_name].reshape(*([-1] + dim))
-        idx += length
-    return shaped
-
-def partition_div(fit):
-    """ Returns parameter arrays separated into divergent and non-divergent transitions"""
-    sampler_params = fit.get_sampler_params(inc_warmup=False)
-    div = numpy.concatenate([x['divergent__'] for x in sampler_params]).astype('int')
-    params = _shaped_ordered_params(fit)
-    nondiv_params = dict((key, params[key][div == 0]) for key in params)
-    div_params = dict((key, params[key][div == 1]) for key in params)
-    return nondiv_params, div_params

--- a/pystan/diagnostics.py
+++ b/pystan/diagnostics.py
@@ -305,6 +305,8 @@ def check_n_eff(fit, verbose = True):
         if verbosity > 0:
             logger.warning('n_eff / iter below 0.001 indicates that the effective sample size has likely been overestimated')
 
+        return False
+
 def check_rhat(fit, verbose = True):
     """Checks the potential scale reduction factors, i.e., Rhat values
 

--- a/pystan/diagnostics.py
+++ b/pystan/diagnostics.py
@@ -1,0 +1,380 @@
+import pystan
+import pickle
+import numpy
+import warnings
+
+# Diagnostics modified from Betancourt's stan_utility.py module
+
+def check_div(fit, verbose = True):
+    """Check transitions that ended with a divergence
+
+    This function returns True if there are no problems with divergent
+    transitions and False otherwise.
+    
+    Optional argument "verbose" is either a Boolean or an integral
+    value.
+
+    If "verbose" is True (the default) or an integer greater than
+    zero, then a diagnostic message is printed only if there are
+    divergent transitions.
+
+    If "verbose" is greater than 1, then extra diagnostic messages are
+    printed.
+
+    If "verbose" is False or zero, no diagnostic messages are
+    printed, and only the return value of the function conveys
+    diagnostic information.
+
+    """
+
+    verbosity = int(verbose)
+    
+    sampler_params = fit.get_sampler_params(inc_warmup=False)
+
+    try:
+        divergent = [x for y in sampler_params for x in y['divergent__']]
+    except:
+        raise ValueError('Cannot access divergence information from fit object')
+    
+    n = sum(divergent)
+    
+    if n > 0:
+        N = len(divergent)
+
+        if verbosity > 0:
+            print('{} of {} iterations ended with a divergence ({}%).'.format(n, N,
+                                                                             100 * n / N))
+
+            try:
+                adapt_delta = fit.stan_args[0]['ctrl']['sampling']['adapt_delta']
+            except:
+                warnings.warn('Cannot obtain value of adapt_delta from fit object')
+                adapt_delta = None
+
+            if adapt_delta != None:
+                print('Try running with adapt_delta larger than {}'.format(adapt_delta) +
+                      ' to remove the divergences.')
+            else:        
+                print('Try running with larger adapt_delta to remove the divergences.')
+
+        return False
+    else:
+        if verbosity > 1:
+            print ('No divergent transitions found.')
+
+        return True
+        
+
+def check_treedepth(fit, verbose = True):
+    """Check transitions that ended prematurely due to maximum tree depth limit
+
+    This function returns True if there are no problems with tree
+    depth and False otherwise.
+    
+    Optional argument "verbose" is either a Boolean or an integral
+    value.
+
+    If "verbose" is True (the default) or an integer greater than
+    zero, then a diagnostic message is printed only if there are
+    transitions that ended ended prematurely due to maximum tree depth
+    limit.
+
+    If "verbose" is greater than 1, then extra diagnostic messages are
+    printed.
+
+    If "verbose" is False or zero, no diagnostic messages are
+    printed, and only the return value of the function conveys
+    diagnostic information.
+
+    """
+
+    verbosity = int(verbose)
+    
+    sampler_params = fit.get_sampler_params(inc_warmup=False)
+
+    try:    
+        depths = [x for y in sampler_params for x in y['treedepth__']]
+    except:
+        raise ValueError('Cannot access tree depth information from fit object')
+
+    try:
+        max_treedepth = fit.stan_args[0]['ctrl']['sampling']['max_treedepth']
+    except:
+        raise ValueError('Cannot obtain value of max_treedepth from fit object')
+        
+    n = sum(1 for x in depths if x >= max_treedepth)
+    
+    if n > 0:
+        if verbosity > 0:
+            N = len(depths)
+            print(('{} of {} iterations saturated the maximum tree depth of {}'
+                   + ' ({}%)').format(n, N, max_treedepth, 100 * n / N))
+            print('Run again with max_treedepth larger than {}'.format(max_treedepth) +
+                  ' to avoid saturation')
+
+        return False
+    else:
+        if verbosity > 1:
+            print('No transitions that ended prematurely due to maximum tree depth limit')
+        
+        return True
+
+def check_energy(fit, verbose = True):
+    """Checks the energy Bayesian fraction of missing information (E-BFMI)
+
+    This function returns True if there are no problems with E-BFMI
+    and False otherwise.
+    
+    Optional argument "verbose" is either a Boolean or an integral
+    value.
+
+    If "verbose" is True (the default) or an integer greater than
+    zero, then diagnostic messages are printed only if there is low
+    E-BFMI in one or more chains.
+
+    If "verbose" is greater than 1, then extra diagnostic messages are
+    printed.
+
+    If "verbose" is False or zero, no diagnostic messages are
+    printed, and only the return value of the function conveys
+    diagnostic information.
+
+    """
+
+    verbosity = int(verbose)
+    
+    sampler_params = fit.get_sampler_params(inc_warmup=False)
+    
+    no_warning = True
+    for chain_num, s in enumerate(sampler_params):
+
+        try:
+            energies = s['energy__']
+        except:
+            raise ValueError('energy__ not in sampler params of fit object')
+            
+        numer = sum((energies[i] - energies[i - 1])**2 for i in range(1, len(energies))) / len(energies)
+        denom = numpy.var(energies)
+        
+        if numer / denom < 0.2:
+            if verbosity > 0:
+                print('Chain {}: E-BFMI = {}'.format(chain_num, numer / denom))
+                
+            no_warning = False
+            
+    if no_warning:
+        if verbosity > 1:
+            print('E-BFMI indicated no pathological behavior')
+            
+        return True
+    else:
+        if verbosity > 0:
+            print('E-BFMI below 0.2 indicates you may need to reparameterize your model')
+            
+        return False
+
+def check_n_eff(fit, verbose = True):
+    """Checks the effective sample size per iteration
+
+    This function returns True if there are no problems with effective
+    sample size.
+    
+    Optional argument "verbose" is either a Boolean or an integral
+    value.
+
+    If "verbose" is True (the default) or an integer greater than
+    zero, then diagnostic messages are printed only if there are
+    effective sample sizes that appear pathologically low.
+
+    If "verbose" is greater than 1, then extra diagnostic messages are
+    printed.
+
+    If "verbose" is False or zero, no diagnostic messages are
+    printed, and only the return value of the function conveys
+    diagnostic information.
+
+    """
+
+    verbosity = int(verbose)
+    
+    fit_summary = fit.summary(probs=[0.5])
+
+    try:
+        n_effs_index = fit_summary['summary_colnames'].index('n_eff')
+    except:
+        raise ValueError('Summary of fit object appears to lack information on effective sample size')
+        
+    n_effs = [x[n_effs_index] for x in fit_summary['summary']]
+    names = fit_summary['summary_rownames']
+    n_iter = len(fit.extract()['lp__'])
+
+    no_warning = True
+    for n_eff, name in zip(n_effs, names):
+        ratio = n_eff / n_iter
+        if (ratio < 0.001):
+            if verbosity > 0:
+                print('n_eff / iter for parameter {} is {}!'.format(name, ratio))
+                
+            no_warning = False
+            
+    if no_warning:
+        if verbosity > 1:
+            print('n_eff / iter looks reasonable for all parameters')
+
+        return True
+    else:
+        if verbosity > 0:
+            print('n_eff / iter below 0.001 indicates that the effective sample size has likely been overestimated')
+
+def check_rhat(fit, verbose = True):
+    """Checks the potential scale reduction factors
+
+    This function returns True if there are no problems with Rhat, the
+    potential scale reduction factor
+    
+    Optional argument "verbose" is either a Boolean or an integral
+    value.
+
+    If "verbose" is True (the default) or an integer greater than
+    zero, then diagnostic messages are printed only if there are Rhat
+    values too far from 1.
+
+    If "verbose" is greater than 1, then extra diagnostic messages are
+    printed.
+
+    If "verbose" is False or zero, no diagnostic messages are
+    printed, and only the return value of the function conveys
+    diagnostic information.
+
+    """
+    
+    from math import isnan
+    from math import isinf
+
+    verbosity = int(verbose)
+
+    fit_summary = fit.summary(probs=[0.5])
+
+    try:
+        Rhat_index = fit_summary['summary_colnames'].index('Rhat')
+    except:
+        raise ValueError('Summary of fit object appears to lack information on Rhat')
+    
+    rhats = [x[Rhat_index] for x in fit_summary['summary']]
+    names = fit_summary['summary_rownames']
+
+    no_warning = True
+    for rhat, name in zip(rhats, names):
+        if (isnan(rhat) or isinf(rhat) or rhat > 1.1 or rhat < 0.9):
+
+            if verbosity > 0:
+                print('Rhat for parameter {} is {}!'.format(name, rhat))
+                
+            no_warning = False
+            
+    if no_warning:
+        if verbosity > 1:
+            print('Rhat looks reasonable for all parameters')
+
+        return True
+    else:
+        if verbosity > 0:
+            print('Rhat above 1.1 or below 0.9 indicates that the chains very likely have not mixed')
+
+        return False
+
+def check_MCMC_diagnostics(fit, verbose = True):
+    """Checks all MCMC diagnostics
+
+    This function returns a dictionary where each key returns a
+    diagnostic check, and the value associated with each key is a
+    Boolean value that is True if the check passed and False
+    otherwise.
+
+    Possible valid keys are 'n_eff', 'Rhat', 'divergence',
+    'treedepth', and 'energy', though which keys are available will
+    depend upon the sampling algorithm used.
+    
+    Optional argument "verbose" is either a Boolean or an integral
+    value.
+
+    If "verbose" is True (the default) or an integer greater than
+    zero, then diagnostic messages are printed only if there are Rhat
+    values too far from 1.
+
+    If "verbose" is greater than 1, then extra diagnostic messages are
+    printed.
+
+    If "verbose" is False or zero, no diagnostic messages are
+    printed, and only the return value of the function conveys
+    diagnostic information.
+
+    """
+
+    # For consistency with the individual diagnostic functions
+    verbosity = int(verbose)
+
+    out_dict = {}
+
+    try:
+        out_dict['n_eff'] = check_n_eff(fit, verbose)
+    except ValueError:
+        if verbosity > 0:
+            print('Skipping check of effective sample size (n_eff)')
+
+    try:
+        out_dict['Rhat'] = check_rhat(fit, verbose)
+    except ValueError:
+        if verbosity > 0:     
+            print('Skipping check of potential scale reduction factors (Rhat)')
+
+    try:
+        out_dict['divergence'] = check_div(fit, verbose)
+    except ValueError:        
+        if verbosity > 0:     
+            print('Skipping check of divergent transitions (divergence)')
+
+    try:
+        out_dict['treedepth'] = check_treedepth(fit, verbose)
+    except ValueError: 
+        if verbosity > 0:     
+            print('Skipping check of transitions ending prematurely due to maximum tree depth limit (treedepth)')
+
+    try:
+        out_dict['energy'] = check_energy(fit, verbose)
+    except ValueError:         
+        if verbosity > 0:     
+            print('Skipping check of E-BFMI (energy)')
+
+    return out_dict
+
+def _by_chain(unpermuted_extraction):
+    num_chains = len(unpermuted_extraction[0])
+    result = [[] for _ in range(num_chains)]
+    for c in range(num_chains):
+        for i in range(len(unpermuted_extraction)):
+            result[c].append(unpermuted_extraction[i][c])
+    return numpy.array(result)
+
+def _shaped_ordered_params(fit):
+    ef = fit.extract(permuted=False, inc_warmup=False) # flattened, unpermuted, by (iteration, chain)
+    ef = _by_chain(ef)
+    ef = ef.reshape(-1, len(ef[0][0]))
+    ef = ef[:, 0:len(fit.flatnames)] # drop lp__
+    shaped = {}
+    idx = 0
+    for dim, param_name in zip(fit.par_dims, fit.extract().keys()):
+        length = int(numpy.prod(dim))
+        shaped[param_name] = ef[:,idx:idx + length]
+        shaped[param_name].reshape(*([-1] + dim))
+        idx += length
+    return shaped
+
+def partition_div(fit):
+    """ Returns parameter arrays separated into divergent and non-divergent transitions"""
+    sampler_params = fit.get_sampler_params(inc_warmup=False)
+    div = numpy.concatenate([x['divergent__'] for x in sampler_params]).astype('int')
+    params = _shaped_ordered_params(fit)
+    nondiv_params = dict((key, params[key][div == 0]) for key in params)
+    div_params = dict((key, params[key][div == 1]) for key in params)
+    return nondiv_params, div_params

--- a/pystan/model.py
+++ b/pystan/model.py
@@ -36,6 +36,7 @@ import numpy as np
 
 import pystan.api
 import pystan.misc
+import pystan.diagnostics
 
 logger = logging.getLogger('pystan')
 
@@ -754,6 +755,9 @@ class StanModel:
         fit.stan_args = args_list
         fit.stanmodel = self
         fit.date = datetime.datetime.now()
+
+        throwaway = pystan.diagnostics.check_MCMC_diagnostics(fit)
+        
         return fit
 
     def vb(self, data=None, pars=None, iter=10000,

--- a/pystan/model.py
+++ b/pystan/model.py
@@ -756,6 +756,8 @@ class StanModel:
         fit.stanmodel = self
         fit.date = datetime.datetime.now()
 
+        # If problems are found in the fit, this will print diagnostic
+        # messages.
         throwaway = pystan.diagnostics.check_MCMC_diagnostics(fit)
         
         return fit


### PR DESCRIPTION
#### Summary:

Addition of diagnostic functions to PyStan, based on Michael Betancourt's [stan_utility.py](https://github.com/betanalpha/jupyter_case_studies/blob/master/pystan_workflow/stan_utility.py).

Also, in emulation of similar functionality in RStan, said diagnostics are automatically run after executing the `sampling()` method of `StanModel`.

#### Intended Effect:

To make it harder for users of PyStan to accidentally proceed with a poor sampling of a model.

#### How to Verify:

Currently, the least bad way to verify the diagnostics is to run them on fits of known bad models, such as the centered eight-schools example in http://mc-stan.org/users/documentation/case-studies/pystan_workflow.html

#### Side Effects:

Extra diagnostic information may be printed out.

#### Documentation:

Currently, the documentation is limited to the docstrings of the diagnostic functions.

#### Copyright and Licensing

The diagnostic functions are based on source code from Michael Betancourt, and the license for them as follows:

> The code in this repository is copyrighted by Columbia University and licensed under the new BSD (3-clause) license:  https://opensource.org/licenses/BSD-3-Clause
> 
> The text in this repository is copyrighted by Michael Betancourt and licensed under the CC BY-NC 4.0 license: https://creativecommons.org/licenses/by-nc/4.0/

I gather that my modifications to that code, as well as my modifications to other parts of PyStan, should be licensed as GPL 3.0.