### PR TITLE
Rename diagnostic function to use snake case.

### DIFF
--- a/pystan/__init__.py
+++ b/pystan/__init__.py
@@ -8,7 +8,7 @@ import logging
 
 from pystan.api import stanc, stan
 from pystan.misc import read_rdump, stan_rdump, stansummary
-from pystan.diagnostics import check_MCMC_diagnostics
+from pystan.diagnostics import check_mcmc_diagnostics
 from pystan.model import StanModel
 from pystan.lookup import lookup
 

--- a/pystan/diagnostics.py
+++ b/pystan/diagnostics.py
@@ -367,7 +367,7 @@ def check_rhat(fit, verbose = True):
 
         return False
 
-def check_MCMC_diagnostics(fit, verbose = True, per_chain = False):
+def check_mcmc_diagnostics(fit, verbose = True, per_chain = False):
     """Checks all MCMC diagnostics
 
     Parameters

--- a/pystan/model.py
+++ b/pystan/model.py
@@ -758,8 +758,8 @@ class StanModel:
 
         # If problems are found in the fit, this will print diagnostic
         # messages.
-        throwaway = pystan.diagnostics.check_MCMC_diagnostics(fit)
-        
+        pystan.diagnostics.check_mcmc_diagnostics(fit)  # noqa
+
         return fit
 
     def vb(self, data=None, pars=None, iter=10000,


### PR DESCRIPTION
Function names use snake case (e.g., ``lower_case_with_underscores``).
It's not specified explicitly by PEP8 but it is almost a universal
practice.