### PR TITLE
Fix spurious NaNs in split_potential_scale_reduction

### DIFF
--- a/pystan/_chains.pyx
+++ b/pystan/_chains.pyx
@@ -229,10 +229,7 @@ def split_potential_scale_reduction(dict sim, int n):
     cdef double var_between = n_samples / 2 * stan_variance(split_chain_mean)
     cdef double var_within = stan_mean(split_chain_var)
 
-    if var_within < pystan.constants.EPSILON:
-        srhat = float('nan')
-    else:
-        srhat = sqrt((var_between/var_within + n_samples / 2 - 1)/ (n_samples / 2))
+    srhat = sqrt((var_between/var_within + n_samples / 2 - 1)/ (n_samples / 2))
     return srhat
 
 

--- a/pystan/_chains.pyx
+++ b/pystan/_chains.pyx
@@ -229,7 +229,7 @@ def split_potential_scale_reduction(dict sim, int n):
     cdef double var_between = n_samples / 2 * stan_variance(split_chain_mean)
     cdef double var_within = stan_mean(split_chain_var)
 
-    srhat = sqrt((var_between/var_within + n_samples / 2 - 1)/ (n_samples / 2))
+    srhat = sqrt((var_between / var_within + n_samples / 2 - 1) / (n_samples / 2))
     return srhat
 
 

--- a/pystan/constants.py
+++ b/pystan/constants.py
@@ -1,5 +1,4 @@
 MAX_UINT = 2**31 - 1  # conservative choice, maximum unsigned int on 32-bit Python 2.7
-EPSILON = 1e-6
 
 try:
     from enum import Enum  # Python 3.4


### PR DESCRIPTION
The function `split_potential_scale_reduction()` in `_chains.pyx`, which calculates Rhat, has a problem where it compares a value to another arbitrary value that is presumed to be "close enough" to zero. Here are the lines in question:
```
if var_within < pystan.constants.EPSILON:
    srhat = float('nan')
else:
    srhat = sqrt((var_between/var_within + n_samples / 2 - 1)/ (n_samples / 2))
```
The problem is that it is quite possible to get a value of `var_within` less than `pystan.constants.EPSILON` (which is only 1e-6, rather than machine epsilon) even if the parameter in question isn't pathological. (I've had this happen, so it isn't just a hypothetical. Also see some of the discussion in the old issue #133.)

Furthermore, since `cdivision` is `True` for `split_potential_scale_reduction`, even if `var_within` is zero, there shouldn't be a `ZeroDivisionError` exception, so there's no need for that comparison. In the case of division by zero, `split_potential_scale_reduction()` would produce a *non*-spurious Inf or NaN.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): James J. Ramsey

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: GPLv3 (http://opensource.org/licenses/GPL-3.0)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
