### PR TITLE
remove .to_pandas renaming

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -235,7 +235,7 @@ a number of methods.
       pars : {str, sequence of str}
          parameter (or quantile) name(s). If `permuted` is False,
          `pars` is ignored.
-      permuted : bool
+      permuted : bool, default False
          If True, returned samples are permuted. All chains are
          merged and warmup samples are discarded.
       dtypes : dict
@@ -251,3 +251,8 @@ a number of methods.
       Returns
       -------
       df : pandas dataframe
+	
+	   Note
+	   ----
+	   Unlike default in extract (`permuted=True`) 
+	   `.to_dataframe` method returns non-permuted samples (`permuted=False`) with diagnostics params included.

--- a/pystan/misc.py
+++ b/pystan/misc.py
@@ -1134,7 +1134,7 @@ def read_rdump(filename):
         d[name.strip()] = _rdump_value_to_numpy(value.strip())
     return d
 
-def to_dataframe(fit, pars=None, permuted=True, dtypes=None, inc_warmup=False, diagnostics=True):
+def to_dataframe(fit, pars=None, permuted=False, dtypes=None, inc_warmup=False, diagnostics=True):
     """Extract samples as a pandas dataframe for different parameters.
 
     Parameters
@@ -1205,7 +1205,7 @@ def to_dataframe(fit, pars=None, permuted=True, dtypes=None, inc_warmup=False, d
                 flatname for flatname in fit.flatnames if flatname.startswith(par)
                 ]
                 for idx in np.arange(ss.shape[1]):
-                    column_name = par_flatnames[idx].replace('[','_').replace(',','_').replace(']','')
+                    column_name = par_flatnames[idx]
                     df[column_name] = ss[:,idx]
     else:
         n_save = fit.sim['n_save'][0]
@@ -1214,7 +1214,7 @@ def to_dataframe(fit, pars=None, permuted=True, dtypes=None, inc_warmup=False, d
         chain_count = fit.sim['chains']+1
         df['chain'] =  (np.arange(1,chain_count)[:,np.newaxis]*np.ones((chain_count-1,n_save))).astype(int).flatten()
         df['chain_idx'] = np.tile(np.arange(1,n_save+1),(chain_count-1,1)).flatten()
-		# Specify whether row is from warmup, 0 means not in warmup
+	# Specify whether row is from warmup, 0 means not in warmup
         df['warmup'] = 0
         # Modify this below if sample is from warmup
         if inc_warmup:
@@ -1237,6 +1237,6 @@ def to_dataframe(fit, pars=None, permuted=True, dtypes=None, inc_warmup=False, d
             if (par in pars) or (par[:par.find('[')] in pars):
                 chains = pystan.misc._get_samples(n, fit.sim, inc_warmup)
                 samples = np.array(chains).T
-                column_name = fit.sim['fnames_oi'][n].replace('[','_').replace(',','_').replace(']','')
+                column_name = fit.sim['fnames_oi'][n]
                 df[column_name] = samples.T.flatten()
     return df

--- a/pystan/stanfit4model.pyx
+++ b/pystan/stanfit4model.pyx
@@ -867,7 +867,7 @@ cdef class StanFit4Model:
         pars : {str, sequence of str}
            parameter (or quantile) name(s). If `permuted` is False,
            `pars` is ignored.
-        permuted : bool
+        permuted : bool, default False
            If True, returned samples are permuted. All chains are
            merged and warmup samples are discarded.
         dtypes : dict
@@ -883,6 +883,11 @@ cdef class StanFit4Model:
         Returns
         -------
         df : pandas dataframe
+	
+	Note
+	----
+	Unlike default in extract (`permuted=True`) 
+	`.to_dataframe` method returns non-permuted samples (`permuted=False`) with diagnostics params included.
 
         """
         return pystan.misc.to_dataframe(fit=self, pars=pars, permuted=permuted, dtypes=dtypes, inc_warmup=inc_warmup, diagnostics=diagnostics)

--- a/pystan/tests/test_extract.py
+++ b/pystan/tests/test_extract.py
@@ -133,10 +133,10 @@ class TestExtract(unittest.TestCase):
         self.assertEqual(df.shape, (4000,9))
         for idx in range(2):
             for jdx in range(3):
-                name = 'alpha_{}_{}'.format(idx+1,jdx+1)
+                name = 'alpha[{},{}]'.format(idx+1,jdx+1)
                 assert_array_equal(df[name].values,alpha[:,idx,jdx])
         for idx in range(2):
-            name = 'beta_{}'.format(idx+1)
+            name = 'beta[{}]'.format(idx+1)
             assert_array_equal(df[name].values,beta[:,idx])
         assert_array_equal(df['lp__'].values,lp__)
         # Test pars argument
@@ -144,7 +144,7 @@ class TestExtract(unittest.TestCase):
         self.assertEqual(df.shape, (4000,6))
         for idx in range(2):
             for jdx in range(3):
-                name = 'alpha_{}_{}'.format(idx+1,jdx+1)
+                name = 'alpha[{},{}]'.format(idx+1,jdx+1)
                 assert_array_equal(df[name].values,alpha[:,idx,jdx])
         # Test pars and dtype argument
         df = self.fit.to_dataframe(pars='alpha',dtypes = {'alpha':np.int})
@@ -152,7 +152,7 @@ class TestExtract(unittest.TestCase):
         self.assertEqual(df.shape, (4000,6))
         for idx in range(2):
             for jdx in range(3):
-                name = 'alpha_{}_{}'.format(idx+1,jdx+1)
+                name = 'alpha[{},{}]'.format(idx+1,jdx+1)
                 assert_array_equal(df[name].values,alpha_int[:,idx,jdx])
 
     def test_to_dataframe_permuted_false_inc_warmup_false(self):
@@ -165,14 +165,14 @@ class TestExtract(unittest.TestCase):
         alpha_index = 0
         for jdx in range(3):
             for idx in range(2):
-                name = 'alpha_{}_{}'.format(idx+1,jdx+1)
+                name = 'alpha[{},{}]'.format(idx+1,jdx+1)
                 for n in range(1,num_chains+1):
                     assert_array_equal(
                     df[name].loc[df.chain == n].values,ss[:,n-1,alpha_index]
                     )
                 alpha_index += 1
         for idx in range(2):
-            name = 'beta_{}'.format(idx+1)
+            name = 'beta[{}]'.format(idx+1)
             for n in range(1,num_chains+1):
                 assert_array_equal(
                 df[name].loc[df.chain == n].values,ss[:,n-1,6+idx]
@@ -206,14 +206,14 @@ class TestExtract(unittest.TestCase):
         alpha_index = 0
         for jdx in range(3):
             for idx in range(2):
-                name = 'alpha_{}_{}'.format(idx+1,jdx+1)
+                name = 'alpha[{},{}]'.format(idx+1,jdx+1)
                 for n in range(1,num_chains+1):
                     assert_array_equal(
                     df[name].loc[df.chain == n].values,ss[:,n-1,alpha_index]
                     )
                 alpha_index += 1
         for idx in range(2):
-            name = 'beta_{}'.format(idx+1)
+            name = 'beta[{}]'.format(idx+1)
             for n in range(1,num_chains+1):
                 assert_array_equal(
                 df[name].loc[df.chain == n].values,ss[:,n-1,6+idx]
@@ -254,14 +254,14 @@ class TestExtract(unittest.TestCase):
         alpha_index = 0
         for jdx in range(3):
             for idx in range(2):
-                name = 'alpha_{}_{}'.format(idx+1,jdx+1)
+                name = 'alpha[{},{}]'.format(idx+1,jdx+1)
                 for n in range(1,num_chains+1):
                     assert_array_equal(
                     df[name].loc[df.chain == n].values,ss[:,n-1,alpha_index]
                     )
                 alpha_index += 1
         for idx in range(2):
-            name = 'beta_{}'.format(idx+1)
+            name = 'beta[{}]'.format(idx+1)
             for n in range(1,num_chains+1):
                 assert_array_equal(
                 df[name].loc[df.chain == n].values,ss[:,n-1,6+idx]
@@ -288,7 +288,7 @@ class TestExtract(unittest.TestCase):
         alpha_index = 0
         for jdx in range(3):
             for idx in range(2):
-                name = 'alpha_{}_{}'.format(idx+1,jdx+1)
+                name = 'alpha[{},{}]'.format(idx+1,jdx+1)
                 for n in range(1,num_chains+1):
                     assert_array_equal(
                     df[name].loc[df.chain == n].values,ss[:,n-1,alpha_index]


### PR DESCRIPTION
Remove underscore renaming from pandas dataframe for parameters (vectors, matrices, arrays)
Change permuted=False as a default to stop warning about permuted=True and diagnostics=True.

#### Summary:

Change `.to_dataframe` behaviour.
Default to permuted=False, to stop outputting warning as a default.

#### Intended Effect:

Keep same names as fit.summary

Enables one to use `vector[N] X` and `real X_1` in the same program code.

#### How to Verify:

    print(fit)
    print(fit.to_dataframe())

`fit.to_dataframe(['X_1', 'X'])`

#### Side Effects:

Permuted=False as a default for dataframe.

#### Documentation:

None needed?

#### Reviewer Suggestions: 

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Ari Hartikainen

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: GPLv3 (http://opensource.org/licenses/GPL-3.0)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
