### PR TITLE
Add option to disable diagnostics after sampling

### DIFF
--- a/pystan/__init__.py
+++ b/pystan/__init__.py
@@ -8,7 +8,7 @@ import logging
 
 from pystan.api import stanc, stan
 from pystan.misc import read_rdump, stan_rdump, stansummary
-from pystan.diagnostics import check_mcmc_diagnostics
+from pystan.diagnostics import check_hmc_diagnostics
 from pystan.model import StanModel
 from pystan.lookup import lookup
 

--- a/pystan/diagnostics.py
+++ b/pystan/diagnostics.py
@@ -367,7 +367,7 @@ def check_rhat(fit, verbose = True):
 
         return False
 
-def check_mcmc_diagnostics(fit, verbose = True, per_chain = False):
+def check_hmc_diagnostics(fit, verbose = True, per_chain = False):
     """Checks all MCMC diagnostics
 
     Parameters

--- a/pystan/model.py
+++ b/pystan/model.py
@@ -645,8 +645,8 @@ class StanModel:
             during sampling (i.e. show the progress every \code{refresh} iterations).
             By default, `refresh` is `max(iter/10, 1)`.
             
-        check_diagnostics : bool, optional
-            After sampling run `pystan.diagnostics.check_mcmc_diagnostics` function.
+        check_hmc_diagnostics : bool, optional
+            After sampling run `pystan.diagnostics.check_hmc_diagnostics` function.
             Default is `True`.
 
         Examples
@@ -700,7 +700,7 @@ class StanModel:
             raise ValueError("The number of chains is less than one; sampling"
                              "not done.")
         
-        check_diagnostics = kwargs.pop('check_diagnostics', True)
+        check_hmc_diagnostics = kwargs.pop('check_hmc_diagnostics', True)
         # check that arguments in kwargs are valid
         valid_args = {"chain_id", "init_r", "test_grad", "append_samples", "refresh", "control"}
         for arg in kwargs:
@@ -763,8 +763,8 @@ class StanModel:
 
         # If problems are found in the fit, this will print diagnostic
         # messages.
-        if check_diagnostics:
-            pystan.diagnostics.check_mcmc_diagnostics(fit)  # noqa
+        if check_hmc_diagnostics:
+            pystan.diagnostics.check_hmc_diagnostics(fit)  # noqa
 
         return fit
 

--- a/pystan/model.py
+++ b/pystan/model.py
@@ -644,6 +644,10 @@ class StanModel:
             Argument `refresh` can be used to control how to indicate the progress
             during sampling (i.e. show the progress every \code{refresh} iterations).
             By default, `refresh` is `max(iter/10, 1)`.
+            
+        check_diagnostics : bool, optional
+            After sampling run `pystan.diagnostics.check_mcmc_diagnostics` function.
+            Default is `True`.
 
         Examples
         --------
@@ -695,7 +699,8 @@ class StanModel:
         if chains < 1:
             raise ValueError("The number of chains is less than one; sampling"
                              "not done.")
-
+        
+        check_diagnostics = kwargs.pop(check_diagnostics, True)
         # check that arguments in kwargs are valid
         valid_args = {"chain_id", "init_r", "test_grad", "append_samples", "refresh", "control"}
         for arg in kwargs:
@@ -758,7 +763,8 @@ class StanModel:
 
         # If problems are found in the fit, this will print diagnostic
         # messages.
-        pystan.diagnostics.check_mcmc_diagnostics(fit)  # noqa
+        if check_diagnostics:
+            pystan.diagnostics.check_mcmc_diagnostics(fit)  # noqa
 
         return fit
 

--- a/pystan/model.py
+++ b/pystan/model.py
@@ -700,7 +700,7 @@ class StanModel:
             raise ValueError("The number of chains is less than one; sampling"
                              "not done.")
         
-        check_diagnostics = kwargs.pop(check_diagnostics, True)
+        check_diagnostics = kwargs.pop('check_diagnostics', True)
         # check that arguments in kwargs are valid
         valid_args = {"chain_id", "init_r", "test_grad", "append_samples", "refresh", "control"}
         for arg in kwargs:

--- a/pystan/stanfit4model.pyx
+++ b/pystan/stanfit4model.pyx
@@ -859,7 +859,7 @@ cdef class StanFit4Model:
     def get_stanmodel(self):
         return self.stanmodel
 
-    def to_dataframe(self, pars=None, permuted=True, dtypes=None, inc_warmup=False, diagnostics=True):
+    def to_dataframe(self, pars=None, permuted=False, dtypes=None, inc_warmup=False, diagnostics=True):
         """Extract samples as a pandas dataframe for different parameters.
 
         Parameters

--- a/pystan/tests/test_basic.py
+++ b/pystan/tests/test_basic.py
@@ -27,6 +27,12 @@ class TestNormal(unittest.TestCase):
         extr = fit.extract()
         y_last, log_prob_last = extr['y'][-1], extr['lp__'][-1]
         self.assertEqual(fit.log_prob(y_last), log_prob_last)
+    
+    def test_check_diagnostics(self):
+        fit = self.model.sampling(iter=10, chains=1, check_diagnostics=True)
+        self.assertIsNotNone(fit)
+        fit2 = self.model.sampling(iter=10, chains=1, check_diagnostics=False)
+        self.assertIsNotNone(fit2)
 
     def test_control_stepsize(self):
         fit = self.model.sampling(control=dict(stepsize=0.001))

--- a/pystan/tests/test_basic.py
+++ b/pystan/tests/test_basic.py
@@ -29,9 +29,9 @@ class TestNormal(unittest.TestCase):
         self.assertEqual(fit.log_prob(y_last), log_prob_last)
     
     def test_check_diagnostics(self):
-        fit = self.model.sampling(iter=10, chains=1, check_diagnostics=True)
+        fit = self.model.sampling(iter=10, chains=1, check_hmc_diagnostics=True)
         self.assertIsNotNone(fit)
-        fit2 = self.model.sampling(iter=10, chains=1, check_diagnostics=False)
+        fit2 = self.model.sampling(iter=10, chains=1, check_hmc_diagnostics=False)
         self.assertIsNotNone(fit2)
 
     def test_control_stepsize(self):

--- a/pystan/tests/test_extract.py
+++ b/pystan/tests/test_extract.py
@@ -129,7 +129,7 @@ class TestExtract(unittest.TestCase):
         alpha = ss['alpha']
         beta = ss['beta']
         lp__ = ss['lp__']
-        df = self.fit.to_dataframe()
+        df = self.fit.to_dataframe(permuted=True)
         self.assertEqual(df.shape, (4000,9))
         for idx in range(2):
             for jdx in range(3):
@@ -140,14 +140,14 @@ class TestExtract(unittest.TestCase):
             assert_array_equal(df[name].values,beta[:,idx])
         assert_array_equal(df['lp__'].values,lp__)
         # Test pars argument
-        df = self.fit.to_dataframe(pars='alpha')
+        df = self.fit.to_dataframe(pars='alpha', permuted=True)
         self.assertEqual(df.shape, (4000,6))
         for idx in range(2):
             for jdx in range(3):
                 name = 'alpha[{},{}]'.format(idx+1,jdx+1)
                 assert_array_equal(df[name].values,alpha[:,idx,jdx])
         # Test pars and dtype argument
-        df = self.fit.to_dataframe(pars='alpha',dtypes = {'alpha':np.int})
+        df = self.fit.to_dataframe(pars='alpha',dtypes = {'alpha':np.int}, permuted=True)
         alpha_int = ss['alpha'].astype(np.int)
         self.assertEqual(df.shape, (4000,6))
         for idx in range(2):


### PR DESCRIPTION
#### Summary:

Add option to disable check_mcmc_diagnostics in sampling function

#### Intended Effect:

If given as `check_diagnostics=False`, no diagnostics is run after sampling is done.

#### How to Verify:

`fit = model.sampling()`
`fit = model.sampling(check_diagnostics=False)`

#### Side Effects:

None

#### Documentation:

Docstring updated.

#### Reviewer Suggestions: 

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Ari Hartikainen

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: GPLv3 (http://opensource.org/licenses/GPL-3.0)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
