### PR TITLE
Remove basicConfig logger

### DIFF
--- a/pystan/__init__.py
+++ b/pystan/__init__.py
@@ -14,8 +14,6 @@ from pystan.lookup import lookup
 
 logger = logging.getLogger('pystan')
 logger.addHandler(logging.NullHandler())
-if len(logger.handlers) == 1:
-    logging.basicConfig(level=logging.INFO)
 
 # following PEP 386
 __version__ = '2.17.1.0'

--- a/pystan/__init__.py
+++ b/pystan/__init__.py
@@ -14,6 +14,8 @@ from pystan.lookup import lookup
 
 logger = logging.getLogger('pystan')
 logger.addHandler(logging.NullHandler())
+if len(logger.handlers) == 1:
+    logger.setLevel(logging.INFO)
 
 # following PEP 386
 __version__ = '2.17.1.0'


### PR DESCRIPTION
Adding the basicConfig call initiates additional handlers, which can interfere with logging of downstream users.

#### Summary:
Currently, when pystan is imported, it can interfere with logging of end users because a basicConfig method is called in __init__.py
#### Intended Effect:

#### How to Verify:
See #465 for verification code. Currently, the test case will not produce a log file. After the pull request is merged, a log file will be created with appropriate logging info.

#### Side Effects:

#### Documentation:
Per logging documentation that basicConfig should not be called in a library:

> Note It is strongly advised that you do not add any handlers other than NullHandler to your library’s loggers. This is because the configuration of handlers is the prerogative of the application developer who uses your library. The application developer knows their target audience and what handlers are most appropriate for their application: if you add handlers ‘under the hood’, you might well interfere with their ability to carry out unit tests and deliver logs which suit their requirements.

[https://docs.python.org/3/howto/logging.html#configuring-logging-for-a-library](https://docs.python.org/3/howto/logging.html#configuring-logging-for-a-library)
#### Reviewer Suggestions: 

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: GPLv3 (http://opensource.org/licenses/GPL-3.0)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
