### PR TITLE
Clean up setup for test_covexpquad

### DIFF
--- a/pystan/tests/test_covexpquad.py
+++ b/pystan/tests/test_covexpquad.py
@@ -6,19 +6,19 @@ class TestCovExpQuad(unittest.TestCase):
     """
     Unit test added to address issue discussed here: https://github.com/stan-dev/pystan/issues/271
     """
-    
-    covexpquad = """
-        data {
-        real rx1[5];
-    }
-    model {
-        matrix[5,5] a;
+    @classmethod
+    def setUpClass(cls):
+      covexpquad = """
+          data {
+          real rx1[5];
+      }
+      model {
+          matrix[5,5] a;
 
-        a = cov_exp_quad(rx1, 1, 1);
-    }
-        """
-
-    model = StanModel(model_code=covexpquad)
+          a = cov_exp_quad(rx1, 1, 1);
+      }
+          """
+      cls.model = StanModel(model_code=covexpquad)
 
     def test_8schools_pars(self):
         model = self.model


### PR DESCRIPTION
#### Summary:
Cleans up the test_covexpquad test setup code. it moves the setup code out of the class body and into a proper setUpClass method.
#### Intended Effect:
This should have no noticeable effect, unless the test_covexpquad test was previously failing for you.  Internally, the setup code will run at the intended time, instead of at import.
#### How to Verify:
Rerun the pystan tests.
#### Side Effects:
Fixes a bug that I was encountering when trying to use pystan with non-standard packaging.
#### Documentation:
https://docs.python.org/2/library/unittest.html#unittest.TestCase.setUpClass (Also note the other pystan tests were using this method correctly)
#### Reviewer Suggestions: 
None
#### Copyright and Licensing
Copyright: Google

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: GPLv3 (http://opensource.org/licenses/GPL-3.0)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

(To be clear, this contribution is approved by Google corporate policy).