### PR TITLE
Fixed 'build on Windows' docs: proposed method for distutils errors, assign value as `compiler=mingw32` instead

### DIFF
--- a/doc/windows.rst
+++ b/doc/windows.rst
@@ -111,7 +111,7 @@ Install `libpython` and `m2w64-toolchain` packages::
 In `PYTHONPATH\\Lib\\distutils` create `distutils.cfg` with text editor (e.g. `notepad`, `notepad++`) and add the following lines::
 
     [build]
-    mingw32
+    compiler=mingw32
     
 To find the correct `distutils` path, run `python`::
 


### PR DESCRIPTION
#### Summary:
Changed docs for Windows build to add the `compiler=` prefix to the distutils setup.

#### Intended Effect: Fix the 
```
configparser.ParsingError: Source contains parsing errors: '$PYTONPATH\\lib\\distutils\\distutils.cfg'
        [line  2]: 'mingw32 \n'
```
error that popped up with proposed method.

#### How to Verify:
Run two vanilla MinGW32 builds on Windows and try both methods.

#### Side Effects:
Documentation fix.

#### Documentation:
Documentation fix.

#### Reviewer Suggestions: 

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: GPLv3 (http://opensource.org/licenses/GPL-3.0)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
