### PR TITLE
resolve np.floating deprecation

### DIFF
--- a/pystan/misc.py
+++ b/pystan/misc.py
@@ -395,7 +395,7 @@ def _split_data(data):
     for k, v in data.items():
         if np.issubdtype(np.asarray(v).dtype, np.integer):
             data_i.update({k.encode('utf-8'): np.asarray(v, dtype=int)})
-        elif np.issubdtype(np.asarray(v).dtype, np.floating):
+        elif np.issubdtype(np.asarray(v).dtype, np.float64):
             data_r.update({k.encode('utf-8'): np.asarray(v, dtype=float)})
         else:
             msg = "Variable {} is neither int nor float nor list/array thereof"


### PR DESCRIPTION
#### Summary:
A small change to resolve the numpy deprecation of `np.floating`. Specifically, this warning: 

```pystan/misc.py:399: FutureWarning: Conversion of the second argument of issubdtype from `float` to `np.floating` is deprecated. In future, it will be treated as `np.float64 == np.dtype(float).type`.
```

#### Intended Effect:
Eliminate deprecation warning. 

#### How to Verify:
re-ran setup.py and ensured this warning no longer occurred.

#### Side Effects:
None.

#### Documentation:
None. 
#### Reviewer Suggestions: 

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: GPLv3 (http://opensource.org/licenses/GPL-3.0)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
