### PR TITLE
CI: remove unused packages from test-requirements.txt

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,11 +1,3 @@
 # The order of packages is significant, because pip processes them in the order
 # of appearance. Changing the order has an impact on the overall integration
 # process, which may cause wedges in the gate later.
-
-hacking>=0.9.2,<0.10
-coverage>=3.6
-discover
-python-subunit
-testrepository>=0.0.18
-testscenarios>=0.4
-testtools>=0.9.34


### PR DESCRIPTION
``test-requirements.txt`` contains packages that are, in fact, not required. Remove them.