### PR TITLE
Add pyproject.toml to help dependency managers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ["cython", "numpy"]


### PR DESCRIPTION
#### Summary:

Add metadata file

#### Intended Effect:

Some dependency managers are able to use the information provided by the `pyproject.toml` file.

It helps to provide install/build-time dependencies information, which is currently the case with C/Cython-related packages.

#### How to Verify:

Installing the package through pip without having previously installed `cython` nor `numpy` and confirm that the installation runs smoothly without problems.

#### Copyright and Licensing

- Andres Correa Casablanca <andres.casablanca@weq.com>

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: GPLv3 (http://opensource.org/licenses/GPL-3.0)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
