### PR TITLE
Faster extract

### DIFF
--- a/pystan/stanfit4model.pyx
+++ b/pystan/stanfit4model.pyx
@@ -540,7 +540,7 @@ cdef class StanFit4Model:
         Parameters
         ----------
         pars : {str, sequence of str}
-           parameter name(s).
+           parameter (or quantile) name(s).
         permuted : bool
            If True, returned samples are permuted. All chains are
            merged and warmup samples are discarded.
@@ -592,7 +592,7 @@ cdef class StanFit4Model:
 
         par_keys = OrderedDict()
         for key in self.sim['fnames_oi']:
-            par = key.replace("]", "").split("[")
+            par = key.split("[")
             par = par[0]
             if par not in par_keys:
                 par_keys[par] = []
@@ -603,9 +603,10 @@ cdef class StanFit4Model:
         return_array = (not permuted) and (pars_original is None)
         extracted = OrderedDict()
 
-        for par, keys in par_keys.items():
+        for par in pars:
+            keys = par_keys.get(par, [par])
             par_samples = []
-            shape = shapes[par]
+            shape = shapes.get(par, [])
             dtype = dtypes.get(par)
             for pyholder, permutation, n_kept_ in zip(self.sim['samples'], self.sim['permutation'], n_kept):
                 arr = itemgetter(*keys)(pyholder.chains)
@@ -878,30 +879,27 @@ cdef class StanFit4Model:
         Parameters
         ----------
         pars : {str, sequence of str}
-           parameter (or quantile) name(s). If `permuted` is False,
-           `pars` is ignored.
+            parameter (or quantile) name(s).
         permuted : bool, default False
-           If True, returned samples are permuted. All chains are
-           merged and warmup samples are discarded.
+            If True, returned samples are permuted.
+            Warmup samples are discarded.
         dtypes : dict
-		    datatype of parameter(s).
-			If nothing is passed, np.float will be used for all parameters.
+		        datatype of parameter(s).
+			      If nothing is passed, np.float will be used for all parameters.
         inc_warmup : bool
-           If True, warmup samples are kept; otherwise they are
-           discarded. If `permuted` is True, `inc_warmup` is ignored.
+            If True, warmup samples are kept; otherwise they are
+            discarded. If `permuted` is True, `inc_warmup` is ignored.
         diagnostics : bool
-	       If True, include MCMC diagnostics in dataframe.
-           If `permuted` is True, `diagnostics` is ignored.
+	          If True, include hmc diagnostics in dataframe.
 
         Returns
         -------
         df : pandas dataframe
 
-	Note
-	----
-	Unlike default in extract (`permuted=True`)
-	`.to_dataframe` method returns non-permuted samples (`permuted=False`) with diagnostics params included.
-
+	      Note
+	      ----
+	      Unlike default in extract (`permuted=True`)
+	      `.to_dataframe` method returns non-permuted samples (`permuted=False`) with diagnostics params included.
         """
         return pystan.misc.to_dataframe(fit=self, pars=pars, permuted=permuted, dtypes=dtypes, inc_warmup=inc_warmup, diagnostics=diagnostics)
 

--- a/pystan/stanfit4model.pyx
+++ b/pystan/stanfit4model.pyx
@@ -35,8 +35,9 @@ from pystan.stan_fit cimport stan_fit, StanArgs, StanHolder, get_all_flatnames
 np.import_array()
 
 # python imports
-import collections
+from collections import OrderedDict
 import logging
+from operator import itemgetter
 import warnings
 
 import numpy as np
@@ -137,7 +138,7 @@ cdef PyStanHolder _pystanholder_from_stanholder(StanHolder* holder):
         chains.append(ch)
         inc(it)
     chain_names = [n.decode('utf-8') for n in holder.chain_names]
-    h.chains = collections.OrderedDict(zip(chain_names, chains))
+    h.chains = OrderedDict(zip(chain_names, chains))
 
     # NOTE: when _pystanholder_from_stanholder is called we also have a pointer
     # to holder.args available so we will use it directly from there. Strictly
@@ -539,8 +540,7 @@ cdef class StanFit4Model:
         Parameters
         ----------
         pars : {str, sequence of str}
-           parameter (or quantile) name(s). If `permuted` is False,
-           `pars` is ignored.
+           parameter name(s).
         permuted : bool
            If True, returned samples are permuted. All chains are
            merged and warmup samples are discarded.
@@ -572,6 +572,7 @@ cdef class StanFit4Model:
         self._verify_has_samples()
         if inc_warmup is True and permuted is True:
             logger.warning("`inc_warmup` ignored when `permuted` is True.")
+            inc_warmup = False
         if dtypes is not None and permuted is False and pars is None:
             logger.warning("`dtypes` ignored when `permuted` is False and `pars` is None")
 
@@ -587,70 +588,49 @@ cdef class StanFit4Model:
         allpars = self.sim['pars_oi'] + self.sim['fnames_oi']
         pystan.misc._check_pars(allpars, pars)
 
-        tidx = pystan.misc._pars_total_indexes(self.sim['pars_oi'],
-                                               self.sim['dims_oi'],
-                                               self.sim['fnames_oi'],
-                                               pars)
+        n_kept = [s if inc_warmup else s-w for s, w in zip(self.sim['n_save'], self.sim['warmup2'])]
 
-        n_kept = [s-w for s, w in zip(self.sim['n_save'], self.sim['warmup2'])]
+        par_keys = OrderedDict()
+        for key in self.sim['fnames_oi']:
+            par = key.replace("]", "").split("[")
+            par = par[0]
+            if par not in par_keys:
+                par_keys[par] = []
+            par_keys[par].append(key)
 
-        if permuted:
-            extracted = collections.OrderedDict()
-            for par in pars:
-                sss = [pystan.misc._get_kept_samples(p, self.sim)
-                       for p in tidx[par]]
-                ss = np.column_stack(sss)
-                if par in dtypes.keys():
-                    ss = ss.astype(dtypes[par])
-                s = {par: ss}
-                extracted.update(s)
-                par_idx = self.sim['pars_oi'].index(par)
-                par_dim = self.sim['dims_oi'][par_idx]
-                # scalars have dim [], otherwise as one would expect
-                par_dim = [1] if par_dim == [] else par_dim
-                newdim = [sum(n_kept)] + par_dim
-                # order='F' means column-major order
-                extracted[par] = extracted[par].reshape(newdim, order='F')
-                # squeeze dim for scalar params, e.g., (4000,1) into (4000,)
-                if len(newdim) == 2 and newdim[1] == 1:
-                    extracted[par] = np.squeeze(extracted[par])
-        elif pars_original is not None:
-            n_chains = self.sim['chains']
-            extracted = collections.OrderedDict()
-            for par in pars:
-                extracted_par = []
-                for n in tidx[par]:
-                    chains = pystan.misc._get_samples(n, self.sim, inc_warmup)
-                    n_save = self.sim['n_save'][0]
-                    if not inc_warmup:
-                        n_save = n_save - self.sim['warmup2'][0]
-                    samples = np.column_stack(chains)
-                    extracted_par.append(samples[:, :, np.newaxis])
-                extracted_par = np.dstack(extracted_par)
-                if par in dtypes.keys():
-                    extracted_par = extracted_par.astype(dtypes[par])
-                extracted[par] = extracted_par
-                par_idx = self.sim['pars_oi'].index(par)
-                par_dim = self.sim['dims_oi'][par_idx]
-                # scalars have dim [], otherwise as one would expect
-                par_dim = [1] if par_dim == [] else par_dim
-                newdim = [n_save, n_chains] + par_dim
-                # order='F' means column-major order
-                extracted[par] = extracted[par].reshape(newdim, order='F')
-                # squeeze dim for scalar params, e.g., (1000,4,1) into (1000,4)
-                if len(newdim) == 3 and newdim[2] == 1:
-                    extracted[par] = np.squeeze(extracted[par])
-        else:
-            extracted = []
-            for n in range(len(self.sim['fnames_oi'])):
-                chains = pystan.misc._get_samples(n, self.sim, inc_warmup)
-                # FIXME: n_save doesn't appear to be used?
-                n_save = self.sim['n_save'][0]
-                if not inc_warmup:
-                    n_save = n_save - self.sim['warmup2'][0]
-                samples = np.array(chains).T
-                extracted.append(samples[:, :, np.newaxis])
-            extracted = np.dstack(extracted)
+        shapes = dict(zip(self.sim['pars_oi'], self.sim['dims_oi']))
+
+        return_array = (not permuted) and (pars_original is None)
+        extracted = OrderedDict()
+
+        for par, keys in par_keys.items():
+            par_samples = []
+            shape = shapes[par]
+            dtype = dtypes.get(par)
+            for pyholder, permutation, n_kept_ in zip(self.sim['samples'], self.sim['permutation'], n_kept):
+                arr = itemgetter(*keys)(pyholder.chains)
+                if shape:
+                    arr = np.column_stack(arr)
+                arr = arr[-n_kept_:]
+                if permuted:
+                    arr = arr[permutation]
+                if not return_array:
+                    new_shape = tuple([-1]+list(shape))
+                    arr = arr.reshape(new_shape, order='F')
+                par_samples.append(arr)
+            if permuted:
+                arr = np.concatenate(par_samples, axis=0)
+            elif (not permuted) and (pars_original is not None):
+                arr = np.stack(par_samples, axis=1)
+            else:
+                arr = np.stack(par_samples, axis=1)
+            if not return_array and len(arr.shape) == 2 and arr.shape[1] == 1:
+                arr = np.squeeze(arr, axis=1)
+            if not return_array:
+              arr = arr.astype(dtype)
+            extracted[par] = arr
+        if return_array:
+            extracted = np.dstack(extracted.values())
         return extracted
 
     def __unicode__(self):
@@ -837,7 +817,7 @@ cdef class StanFit4Model:
         parameter `inc_warmup` indicates whether to include the warmup period.
         """
         self._verify_has_samples()
-        ldf = [collections.OrderedDict(zip(ch['sampler_param_names'], np.array(ch['sampler_params']))) for ch in self.sim['samples']]
+        ldf = [OrderedDict(zip(ch['sampler_param_names'], np.array(ch['sampler_params']))) for ch in self.sim['samples']]
         if inc_warmup:
             return ldf
         else:

--- a/pystan/tests/test_extract.py
+++ b/pystan/tests/test_extract.py
@@ -130,7 +130,7 @@ class TestExtract(unittest.TestCase):
         beta = ss['beta']
         lp__ = ss['lp__']
         df = self.fit.to_dataframe(permuted=True)
-        self.assertEqual(df.shape, (4000,9))
+        self.assertEqual(df.shape, (4000,18))
         for idx in range(2):
             for jdx in range(3):
                 name = 'alpha[{},{}]'.format(idx+1,jdx+1)
@@ -141,7 +141,7 @@ class TestExtract(unittest.TestCase):
         assert_array_equal(df['lp__'].values,lp__)
         # Test pars argument
         df = self.fit.to_dataframe(pars='alpha', permuted=True)
-        self.assertEqual(df.shape, (4000,6))
+        self.assertEqual(df.shape, (4000,15))
         for idx in range(2):
             for jdx in range(3):
                 name = 'alpha[{},{}]'.format(idx+1,jdx+1)
@@ -149,7 +149,7 @@ class TestExtract(unittest.TestCase):
         # Test pars and dtype argument
         df = self.fit.to_dataframe(pars='alpha',dtypes = {'alpha':np.int}, permuted=True)
         alpha_int = ss['alpha'].astype(np.int)
-        self.assertEqual(df.shape, (4000,6))
+        self.assertEqual(df.shape, (4000,15))
         for idx in range(2):
             for jdx in range(3):
                 name = 'alpha[{},{}]'.format(idx+1,jdx+1)
@@ -187,8 +187,8 @@ class TestExtract(unittest.TestCase):
                 (n+1)*np.ones(num_samples,dtype=np.int)
                 )
             assert_array_equal(
-                df.chain_idx.values[n*num_samples:(n+1)*num_samples],
-                np.arange(1,num_samples +1,dtype=np.int)
+                df.draw.values[n*num_samples:(n+1)*num_samples],
+                np.arange(1,num_samples+1,dtype=np.int)
                 )
             for diag, diag_type in diagnostic_type.items():
                 assert_array_equal(
@@ -236,14 +236,15 @@ class TestExtract(unittest.TestCase):
                 (n+1)*np.ones(num_samples,dtype=np.int)
                 )
             assert_array_equal(
-                df.chain_idx.values[n*num_samples:(n+1)*num_samples],
-                np.arange(1,num_samples +1,dtype=np.int)
+                df.draw.values[n*num_samples:(n+1)*num_samples],
+                np.arange(1,num_samples+1,dtype=np.int)
                 )
             for diag, diag_type in diagnostic_type.items():
                 assert_array_equal(
                 df[diag+'__'].values[n*num_samples:(n+1)*num_samples],
                 fit.get_sampler_params()[n][diag+'__'][-num_samples:].astype(diag_type)
                 )
+
     def test_to_dataframe_permuted_false_diagnostics_false(self):
         fit = self.fit
         ss = fit.extract(permuted=False)
@@ -274,8 +275,8 @@ class TestExtract(unittest.TestCase):
                 (n+1)*np.ones(num_samples,dtype=np.int)
                 )
                 assert_array_equal(
-                df.chain_idx.values[n*num_samples:(n+1)*num_samples],
-                np.arange(1,num_samples +1,dtype=np.int)
+                df.draw.values[n*num_samples:(n+1)*num_samples],
+                np.arange(1,num_samples+1,dtype=np.int)
                 )
 
     def test_to_dataframe_permuted_false_pars(self):
@@ -302,8 +303,8 @@ class TestExtract(unittest.TestCase):
                 (n+1)*np.ones(num_samples,dtype=np.int)
                 )
             assert_array_equal(
-                df.chain_idx.values[n*num_samples:(n+1)*num_samples],
-                np.arange(1,num_samples +1,dtype=np.int)
+                df.draw.values[n*num_samples:(n+1)*num_samples],
+                np.arange(1,num_samples+1,dtype=np.int)
                 )
             for diag, diag_type in diagnostic_type.items():
                 assert_array_equal(


### PR DESCRIPTION
#### Summary:

Faster extraction for long and wide formats.

Update for `to_dataframe` to include three column group ` header | parameters | diagnostics `

`header` contains `draw, chain, warmup, [permutation, chain_permutation, permutation_order, chain_permutation_order`]

where `chain_idx` --> `draw`

#### Intended Effect:

Extract takes less time, same results as before

For large problems speedups are 500x and for smaller speedup ~10x

#### How to Verify:

Test results for 1D-nD with different extraction options before and after

#### Side Effects:

Change in `to_dataframe` column names

#### Documentation:

Update for `to_dataframe` to include three column group ` header | parameters | diagnostics `

`header` contains `draw, chain, warmup, [permutation, chain_permutation, permutation_order, chain_permutation_order`]

where `chain_idx` --> `draw`

#### Reviewer Suggestions: 

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Ari Hartikainen

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: GPLv3 (http://opensource.org/licenses/GPL-3.0)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
