### PR TITLE
loop threading test maximum 10 times before failure

### DIFF
--- a/pystan/tests/test_extra_compile_args.py
+++ b/pystan/tests/test_extra_compile_args.py
@@ -42,7 +42,7 @@ class TestExtraCompileArgs(unittest.TestCase):
                              extra_compile_args=extra_compile_args)
 
     def test_threading_support(self):
-        # Dont test with Windows
+        # Dont test with Windows with MinGW-w64 (GCC)
         if sys.platform.startswith("win"):
             return
         # Set up environmental variable
@@ -104,17 +104,25 @@ class TestExtraCompileArgs(unittest.TestCase):
             model_code=stan_code,
             extra_compile_args=extra_compile_args
         )
-        fit = stan_model.sampling(data=stan_data, chains=2, n_jobs=1)
-        self.assertIsNotNone(fit)
-        fit2 = stan_model.sampling(data=stan_data, chains=2, n_jobs=2)
-        self.assertIsNotNone(fit2)
-        draw = fit.extract(pars=fit.model_pars+['lp__'], permuted=False)
-        lp = {key : values[-1, 0] for key, values in draw.items() if key == 'lp__'}['lp__']
-        draw = {key : values[-1, 0] for key, values in draw.items() if key != 'lp__'}
-        draw = fit.unconstrain_pars(draw)
-        self.assertEqual(fit.log_prob(draw), lp)
-        draw2 = fit2.extract(pars=fit2.model_pars+['lp__'], permuted=False)
-        lp2 = {key : values[-1, 0] for key, values in draw2.items() if key == 'lp__'}['lp__']
-        draw2 = {key : values[-1, 0] for key, values in draw2.items() if key != 'lp__'}
-        draw2 = fit2.unconstrain_pars(draw2)
-        self.assertEqual(fit2.log_prob(draw2), lp2)
+        for i in range(10):
+            try:
+                fit = stan_model.sampling(data=stan_data, chains=2, iter=200, n_jobs=1)
+                self.assertIsNotNone(fit)
+                fit2 = stan_model.sampling(data=stan_data, chains=2, iter=200, n_jobs=2)
+                self.assertIsNotNone(fit2)
+                draw = fit.extract(pars=fit.model_pars+['lp__'], permuted=False)
+                lp = {key : values[-1, 0] for key, values in draw.items() if key == 'lp__'}['lp__']
+                draw = {key : values[-1, 0] for key, values in draw.items() if key != 'lp__'}
+                draw = fit.unconstrain_pars(draw)
+                self.assertEqual(fit.log_prob(draw), lp)
+                draw2 = fit2.extract(pars=fit2.model_pars+['lp__'], permuted=False)
+                lp2 = {key : values[-1, 0] for key, values in draw2.items() if key == 'lp__'}['lp__']
+                draw2 = {key : values[-1, 0] for key, values in draw2.items() if key != 'lp__'}
+                draw2 = fit2.unconstrain_pars(draw2)
+                self.assertEqual(fit2.log_prob(draw2), lp2)
+                break
+            except AssertionError:
+                if i < 9:
+                    continue
+                else:
+                    raise


### PR DESCRIPTION
#### Summary:

Threading summation order is not deterministic, which causes numerical problems.

#### Intended Effect:

Given low probability for the failure (1/100 ~ 1/1000), ten iterations should be enough to succesfully pass the test.

#### How to Verify:

Run tests huge amount of times (follow CI in github)

#### Side Effects:

Tests pass with higher probability

#### Documentation:

None, unless Stan docs don't address this issue (give warning)

#### Reviewer Suggestions: 

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):
Ari Hartikainen
By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: GPLv3 (http://opensource.org/licenses/GPL-3.0)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
