### PR TITLE
ISSUE-534 model.py optimizing function raises ValueError for index of 'lp__'

### DIFF
--- a/pystan/model.py
+++ b/pystan/model.py
@@ -513,9 +513,10 @@ class StanModel:
         m_pars = fit._get_param_names()
         p_dims = fit._get_param_dims()
 
-        idx_of_lp = m_pars.index('lp__')
-        del m_pars[idx_of_lp]
-        del p_dims[idx_of_lp]
+        if 'lp__' in m_pars:
+            idx_of_lp = m_pars.index('lp__')
+            del m_pars[idx_of_lp]
+            del p_dims[idx_of_lp]
 
         if isinstance(init, numbers.Number):
             init = str(init)


### PR DESCRIPTION
#### Summary:
Fix for https://github.com/stan-dev/pystan/issues/534
model.py optimizing() function raises ValueError for index of "lp__"
Ran into this issue while calling FB Prophet library, which internally uses PyStan.

Depending on the data (and potentially even the OS), this will raise a ValueError since
idx_of_lp is not found.
```
        idx_of_lp = m_pars.index('lp__')
        del m_pars[idx_of_lp]
        del p_dims[idx_of_lp]
```

Error:
```
ValueError: 'lp__' is not in list
```

#### Intended Effect:
Added robustness.

#### How to Verify:
```
import pandas as pd
from fbprophet import Prophet

df = # initialize data frame
model = Prophet()
model.fit(df)
future = model.make_future_dataframe(periods=24*num_days)
forecast = model.predict(future)
```

#### Side Effects:
None

#### Documentation:
N/A

#### Reviewer Suggestions: 

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

afernandez

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: GPLv3 (http://opensource.org/licenses/GPL-3.0)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
