### PR TITLE
Update hmc diagnostics output

### DIFF
--- a/pystan/diagnostics.py
+++ b/pystan/diagnostics.py
@@ -1,4 +1,6 @@
 import pystan
+from pystan.misc import _check_pars, _remove_empty_pars
+from pystan._compat import string_types
 import numpy as np
 import logging
 
@@ -6,7 +8,7 @@ logger = logging.getLogger('pystan')
 
 # Diagnostics modified from Betancourt's stan_utility.py module
 
-def check_div(fit, verbose = True, per_chain = False):
+def check_div(fit, verbose=True, per_chain=False):
     """Check for transitions that ended with a divergence
 
     Parameters
@@ -18,7 +20,7 @@ def check_div(fit, verbose = True, per_chain = False):
         the function conveys diagnostic information. If it is ``True``
         (the default) or an integer greater than zero, then a
         diagnostic message is printed only if there are divergent
-        transitions. If it is an integer greater than 1, then extra
+        transitions. If it is an integer greater than 2, then extra
         diagnostic messages are printed.
     per_chain : bool, optional
         Print the number of divergent transitions in each chain
@@ -82,13 +84,13 @@ def check_div(fit, verbose = True, per_chain = False):
 
         return False
     else:
-        if verbosity > 1:
+        if verbosity > 2:
             logger.info('No divergent transitions found.')
 
         return True
 
 
-def check_treedepth(fit, verbose = True, per_chain = False):
+def check_treedepth(fit, verbose=True, per_chain=False):
     """Check for transitions that ended prematurely due to maximum tree
     depth limit
 
@@ -102,7 +104,7 @@ def check_treedepth(fit, verbose = True, per_chain = False):
         (the default) or an integer greater than zero, then a
         diagnostic message is printed only if there are transitions
         that ended ended prematurely due to maximum tree depth
-        limit. If it is an integer greater than 1, then extra
+        limit. If it is an integer greater than 2, then extra
         diagnostic messages are printed.
     per_chain : bool, optional
         Print the number of prematurely ending transitions in each chain
@@ -136,9 +138,9 @@ def check_treedepth(fit, verbose = True, per_chain = False):
     except:
         raise ValueError('Cannot obtain value of max_treedepth from fit object')
 
-    n_for_chain =  (depths >= max_treedepth).sum(axis=0)
+    n_for_chains =  (depths >= max_treedepth).sum(axis=0)
 
-    n = n_for_chain.sum()
+    n = n_for_chains.sum()
 
     if n > 0:
         if verbosity > 0:
@@ -163,12 +165,12 @@ def check_treedepth(fit, verbose = True, per_chain = False):
 
         return False
     else:
-        if verbosity > 1:
+        if verbosity > 2:
             logger.info('No transitions that ended prematurely due to maximum tree depth limit')
 
         return True
 
-def check_energy(fit, verbose = True):
+def check_energy(fit, verbose=True):
     """Checks the energy Bayesian fraction of missing information (E-BFMI)
 
     Parameters
@@ -180,7 +182,7 @@ def check_energy(fit, verbose = True):
         the function conveys diagnostic information. If it is ``True``
         (the default) or an integer greater than zero, then a
         diagnostic message is printed only if there is low E-BFMI in
-        one or more chains. If it is an integer greater than 1, then
+        one or more chains. If it is an integer greater than 2, then
         extra diagnostic messages are printed.
 
 
@@ -219,18 +221,18 @@ def check_energy(fit, verbose = True):
 
         if e_bfmi[chain_num] < 0.2:
             if verbosity > 0:
-                logger.warning('Chain {}: E-BFMI = {}'.format(chain_num + 1,
+                logger.warning('Chain {}: E-BFMI = {:.3g}'.format(chain_num + 1,
                                                               e_bfmi[chain_num]))
 
             no_warning = False
         else:
-            if verbosity > 1:
-                logger.info('Chain {}: E-BFMI (= {}) '.format(chain_num + 1,
+            if verbosity > 2:
+                logger.info('Chain {}: E-BFMI (= {:.3g}) '.format(chain_num + 1,
                                                               e_bfmi[chain_num]) +
                             'equals or exceeds threshold of 0.2.')
 
     if no_warning:
-        if verbosity > 1:
+        if verbosity > 2:
             logger.info('E-BFMI indicated no pathological behavior')
 
         return True
@@ -240,12 +242,15 @@ def check_energy(fit, verbose = True):
 
         return False
 
-def check_n_eff(fit, verbose = True):
+def check_n_eff(fit, pars=None, verbose=True):
     """Checks the effective sample size per iteration
 
     Parameters
     ----------
     fit : StanFit4Model object
+    pars : {str, sequence of str}, optional
+        Parameter (or quantile) name(s). Test only specific parameters.
+        Raises an exception if parameter is not valid.
     verbose : bool or int, optional
         If ``verbose`` is ``False`` or a nonpositive integer, no
         diagnostic messages are printed, and only the return value of
@@ -253,7 +258,8 @@ def check_n_eff(fit, verbose = True):
         (the default) or an integer greater than zero, then a
         diagnostic message is printed only if there are effective
         sample sizes that appear pathologically low. If it is an
-        integer greater than 1, then extra diagnostic messages are
+        integer greater than 1, then parameter (quantile) diagnostics
+        are printed. If integer is greater than 2 extra diagnostic messages are
         printed.
 
 
@@ -269,20 +275,49 @@ def check_n_eff(fit, verbose = True):
 
     n_iter = sum(fit.sim['n_save'])-sum(fit.sim['warmup2'])
 
+    if pars is None:
+        pars = fit.sim['fnames_oi']
+    else:
+        if isinstance(pars, string_types):
+            pars = [pars]
+        pars = _remove_empty_pars(pars, fit.sim['pars_oi'], fit.sim['dims_oi'])
+        allpars = fit.sim['pars_oi'] + fit.sim['fnames_oi']
+        _check_pars(allpars, pars)
+        packed_pars = set(pars) - set(fit.sim['fnames_oi'])
+        if packed_pars:
+            unpack_dict = {}
+            for par_unpacked in fit.sim['fnames_oi']:
+                par_packed = par_unpacked.split("[")[0]
+                if par_packed not in unpack_dict:
+                    unpack_dict[par_packed] = []
+                unpack_dict[par_packed].append(par_unpacked)
+            pars_unpacked = []
+            for par in pars:
+                if par in packed_pars:
+                    pars_unpacked.extend(unpack_dict[par])
+                else:
+                    pars_unpacked.append(par)
+            pars = pars_unpacked
+
+    par_n_dict = {}
+    for n, par in enumerate(fit.sim['fnames_oi']):
+        par_n_dict[par] = n
+
     no_warning = True
-    for n, name in enumerate(fit.sim['fnames_oi']):
+    for name in pars:
+        n = par_n_dict[name]
         n_eff = pystan.chains.ess(fit.sim, n)
         ratio = n_eff / n_iter
         if ((ratio < 0.001) or np.isnan(ratio) or np.isinf(ratio)):
-            if verbosity > 0:
-                logger.warning('n_eff / iter for parameter {} is {}!'.format(name, ratio))
+            if verbosity > 1:
+                logger.warning('n_eff / iter for parameter {} is {:.3g}!'.format(name, ratio))
 
             no_warning = False
-            if verbosity <= 0:
+            if verbosity <= 1:
                 break
 
     if no_warning:
-        if verbosity > 1:
+        if verbosity > 2:
             logger.info('n_eff / iter looks reasonable for all parameters')
 
         return True
@@ -292,12 +327,15 @@ def check_n_eff(fit, verbose = True):
 
         return False
 
-def check_rhat(fit, verbose = True):
+def check_rhat(fit, pars=None, verbose=True):
     """Checks the potential scale reduction factors, i.e., Rhat values
 
     Parameters
     ----------
     fit : StanFit4Model object
+    pars : {str, sequence of str}, optional
+        Parameter (or quantile) name(s). Test only specific parameters.
+        Raises an exception if parameter is not valid.
     verbose : bool or int, optional
         If ``verbose`` is ``False`` or a nonpositive integer, no
         diagnostic messages are printed, and only the return value of
@@ -305,7 +343,8 @@ def check_rhat(fit, verbose = True):
         (the default) or an integer greater than zero, then a
         diagnostic message is printed only if there are Rhat values
         too far from 1. If ``verbose`` is an integer greater than 1,
-        then extra diagnostic messages are printed.
+        parameter (quantile) diagnostics are printed. If ``verbose``
+        is an integer greater than 2, then extra diagnostic messages are printed.
 
 
     Returns
@@ -318,21 +357,50 @@ def check_rhat(fit, verbose = True):
 
     verbosity = int(verbose)
 
+    if pars is None:
+        pars = fit.sim['fnames_oi']
+    else:
+        if isinstance(pars, string_types):
+            pars = [pars]
+        pars = _remove_empty_pars(pars, fit.sim['pars_oi'], fit.sim['dims_oi'])
+        allpars = fit.sim['pars_oi'] + fit.sim['fnames_oi']
+        _check_pars(allpars, pars)
+        packed_pars = set(pars) - set(fit.sim['fnames_oi'])
+        if packed_pars:
+            unpack_dict = {}
+            for par_unpacked in fit.sim['fnames_oi']:
+                par_packed = par_unpacked.split("[")[0]
+                if par_packed not in unpack_dict:
+                    unpack_dict[par_packed] = []
+                unpack_dict[par_packed].append(par_unpacked)
+            pars_unpacked = []
+            for par in pars:
+                if par in packed_pars:
+                    pars_unpacked.extend(unpack_dict[par])
+                else:
+                    pars_unpacked.append(par)
+            pars = pars_unpacked
+
+    par_n_dict = {}
+    for n, par in enumerate(fit.sim['fnames_oi']):
+        par_n_dict[par] = n
+
     no_warning = True
-    for n, name in enumerate(fit.sim['fnames_oi']):
+    for name in pars:
+        n = par_n_dict[name]
         rhat = pystan.chains.splitrhat(fit.sim, n)
 
         if (np.isnan(rhat) or np.isinf(rhat) or (rhat > 1.1) or (rhat < 0.9)):
 
-            if verbosity > 0:
-                logger.warning('Rhat for parameter {} is {}!'.format(name, rhat))
+            if verbosity > 1:
+                logger.warning('Rhat for parameter {} is {:.3g}!'.format(name, rhat))
 
             no_warning = False
-            if verbosity <= 0:
+            if verbosity <= 1:
                 break
 
     if no_warning:
-        if verbosity > 1:
+        if verbosity > 2:
             logger.info('Rhat looks reasonable for all parameters')
 
         return True
@@ -342,7 +410,7 @@ def check_rhat(fit, verbose = True):
 
         return False
 
-def check_hmc_diagnostics(fit, verbose = True, per_chain = False):
+def check_hmc_diagnostics(fit, pars=None, verbose=True, per_chain=False):
     """Checks all hmc diagnostics
 
     Parameters
@@ -354,8 +422,9 @@ def check_hmc_diagnostics(fit, verbose = True, per_chain = False):
         the function conveys diagnostic information. If it is ``True``
         (the default) or an integer greater than zero, then diagnostic
         messages are printed only for diagnostic checks that fail. If
-        ``verbose`` is an integer greater than 1, then extra
-        diagnostic messages are printed.
+        ``verbose`` is an integer greater than 1, then parameter
+        (quantile) diagnostics are printed. If ``verbose`` is
+        greater than 2, then extra diagnostic messages are printed.
     per_chain : bool, optional
         Where applicable, print diagnostics on a per-chain basis. This
         applies mainly to the divergence and treedepth checks.
@@ -379,13 +448,13 @@ def check_hmc_diagnostics(fit, verbose = True, per_chain = False):
     out_dict = {}
 
     try:
-        out_dict['n_eff'] = check_n_eff(fit, verbose)
+        out_dict['n_eff'] = check_n_eff(fit, pars, verbose)
     except ValueError:
         if verbosity > 0:
             logger.warning('Skipping check of effective sample size (n_eff)')
 
     try:
-        out_dict['Rhat'] = check_rhat(fit, verbose)
+        out_dict['Rhat'] = check_rhat(fit, pars, verbose)
     except ValueError:
         if verbosity > 0:
             logger.warning('Skipping check of potential scale reduction factors (Rhat)')

--- a/pystan/model.py
+++ b/pystan/model.py
@@ -811,8 +811,8 @@ class StanModel:
         # messages.
         if check_hmc_diagnostics is None and algorithm in ("NUTS", "HMC"):
             if n_flatnames > 1000:
-                msg = "Maximum (flat) parameter count (1000) exceeded: " +
-                      "skipping diagnostic tests for n_eff and Rhat.\n" +
+                msg = "Maximum (flat) parameter count (1000) exceeded: " +\
+                      "skipping diagnostic tests for n_eff and Rhat.\n" +\
                       "To run all diagnostics call pystan.check_hmc_diagnostics(fit)"
                 logger.warning(msg)
                 checks = ["divergence", "treedepth", "energy"]

--- a/pystan/model.py
+++ b/pystan/model.py
@@ -687,7 +687,9 @@ class StanModel:
 
         check_hmc_diagnostics : bool, optional
             After sampling run `pystan.diagnostics.check_hmc_diagnostics` function.
-            Default is `True`.
+            Default is `True`. Checks for n_eff and rhat skipped if the flat
+            parameter count is higher than 1000, unless user explicitly defines
+            ``check_hmc_diagnostics=True``.
 
         Examples
         --------
@@ -744,7 +746,7 @@ class StanModel:
             raise ValueError("The number of chains is less than one; sampling"
                              "not done.")
 
-        check_hmc_diagnostics = kwargs.pop('check_hmc_diagnostics', True)
+        check_hmc_diagnostics = kwargs.pop('check_hmc_diagnostics', None)
         # check that arguments in kwargs are valid
         valid_args = {"chain_id", "init_r", "test_grad", "append_samples", "refresh", "control"}
         for arg in kwargs:
@@ -807,7 +809,17 @@ class StanModel:
 
         # If problems are found in the fit, this will print diagnostic
         # messages.
-        if check_hmc_diagnostics and algorithm in ("NUTS", "HMC"):
+        if check_hmc_diagnostics is None and algorithm in ("NUTS", "HMC"):
+            if n_flatnames > 1000:
+                msg = "Maximum (flat) parameter count (1000) exceeded: " +
+                      "skipping diagnostic tests for n_eff and Rhat.\n" +
+                      "To run all diagnostics call pystan.check_hmc_diagnostics(fit)"
+                logger.warning(msg)
+                checks = ["divergence", "treedepth", "energy"]
+                pystan.diagnostics.check_hmc_diagnostics(fit, checks=checks)  # noqa
+            else:
+                pystan.diagnostics.check_hmc_diagnostics(fit)  # noqa
+        elif check_hmc_diagnostics and algorithm in ("NUTS", "HMC"):
             pystan.diagnostics.check_hmc_diagnostics(fit)  # noqa
 
         return fit


### PR DESCRIPTION
#### Summary:

Add possibility to select only subset of checks (`checks`)

Add possibility to select only a subset of parameters to test (`pars` argument)

New verbose limits for checks
   - False, <=0 <--log nothing
   - True, 1 <-- log only basic
   - 2 <-- log elementwise information
   - \>=3 <-- log helper info

Add 1000 flatname limit to model.sampling unless user explicitly defines `hmc_diagnostics=True`

Bugfixes (missing variable, accuracy to 3 decimals)

#### Intended Effect:

Streamline sampling for huge models
Add possibility for users to manually exclude parameters and tests (Cholesky matrices containing nans etc)

#### How to Verify:

Run model with over 1000 flat parameters.

#### Side Effects:

Faster data to user time, skips diagnostics tests for large models.

#### Documentation:

Docstrings have been updated.

#### Reviewer Suggestions: 

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Ari Hartikainen

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: GPLv3 (http://opensource.org/licenses/GPL-3.0)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
