### PR TITLE
disable check_hmc_diagnostics when test_grad=True

### DIFF
--- a/pystan/model.py
+++ b/pystan/model.py
@@ -809,7 +809,7 @@ class StanModel:
 
         # If problems are found in the fit, this will print diagnostic
         # messages.
-        if check_hmc_diagnostics is None and algorithm in ("NUTS", "HMC"):
+        if (check_hmc_diagnostics is None and algorithm in ("NUTS", "HMC")) and fit.mode != 1:
             if n_flatnames > 1000:
                 msg = "Maximum (flat) parameter count (1000) exceeded: " +\
                       "skipping diagnostic tests for n_eff and Rhat.\n" +\
@@ -819,7 +819,7 @@ class StanModel:
                 pystan.diagnostics.check_hmc_diagnostics(fit, checks=checks)  # noqa
             else:
                 pystan.diagnostics.check_hmc_diagnostics(fit)  # noqa
-        elif check_hmc_diagnostics and algorithm in ("NUTS", "HMC"):
+        elif (check_hmc_diagnostics and algorithm in ("NUTS", "HMC")) and fit.mode != 1:
             pystan.diagnostics.check_hmc_diagnostics(fit)  # noqa
 
         return fit


### PR DESCRIPTION
#### Summary:

Causes python to crash on Windows if hmc_diagnostics is True when test_grad is True.

#### Intended Effect:

Enable test_grad by default

#### How to Verify:

Test test_grad with `check_hmc_diagnostics=False`

#### Side Effects:

#### Documentation:

#### Reviewer Suggestions: 

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):
Ari Hartikainen
By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: GPLv3 (http://opensource.org/licenses/GPL-3.0)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
