### PR TITLE
fix(ci): use newer gcc on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,14 @@ dist: trusty
 sudo: required
 os:
   - linux
+addons:
+  apt:
+    sources:
+    - ubuntu-toolchain-r-test
+  packages:
+    - gcc-5
+    - g++-5
+    - clang
 git:
   submodules: false
 before_install:
@@ -27,5 +35,7 @@ notifications:
       - stan-buildbot@googlegroups.com
     on_success: change
     on_failure: always
-install: source continuous_integration/install.sh
+install:
+  - if [[ $CXX = g++ ]]; then export CXX="g++-5" CC="gcc-5"; fi
+  - source continuous_integration/install.sh
 script: bash continuous_integration/test_script.sh --exclude="$TESTS_EXCLUDE_RE"


### PR DESCRIPTION
Newer gcc needed for Stan 2.19.
