### PR TITLE
fix(ci): use newer gcc on travis (use xenial)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,12 @@
-# language is set to c to work around travis ci bug
-# https://github.com/travis-ci/travis-ci/issues/2312
 language: c
-dist: trusty
+dist: xenial
 sudo: required
 os:
   - linux
 git:
   submodules: false
+services:
+  - xvfb
 before_install:
   - git submodule update --init --recursive
 compiler:

--- a/continuous_integration/install.sh
+++ b/continuous_integration/install.sh
@@ -6,12 +6,6 @@
 
 set -e
 
-if [[ $TRAVIS_OS_NAME == 'linux' ]]; then
-    export DISPLAY=:99.0
-    sh -e /etc/init.d/xvfb start
-fi
-
-
 # steps common to linux and OS X
 
 # use Anaconda to get compiled versions of scipy and numpy,


### PR DESCRIPTION
Newer gcc needed for Stan 2.19.
