### PR TITLE
chore: update release notes, version number

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -6,6 +6,13 @@
  What's New
 ============
 
+v2.19.0.0 (31. Mar 2019)
+========================
+- Update Stan source to v2.19.0 (`release notes <https://github.com/stan-dev/stan/releases/tag/v2.19.0>`_)
+- Stan 2.19 requires a compiler which supports C++14. For example, if you use gcc as your compiler you will need to use gcc version 4.9.3 or higher.
+- New sampler parameters for VB mode: ``log_p__`` and ``log_g__`` values are added to sample file (csv) if defined with ``sample_file``.
+- Reminder: Python 2 is not supported after 2019-12-31. PyStan will phase out testing of Python 2 after this point.
+
 v2.18.1.0 (22. Dec 2018)
 ========================
 - Update Stan source to v2.18.1 (`release notes <https://github.com/stan-dev/stan/releases/tag/v2.18.1>`_)

--- a/pystan/__init__.py
+++ b/pystan/__init__.py
@@ -19,4 +19,4 @@ if len(logger.handlers) == 1:
 
 # following PEP 386
 # See also https://docs.openstack.org/pbr/latest/user/semver.html
-__version__ = '2.18.1.1.dev'
+__version__ = '2.19.0.0'


### PR DESCRIPTION
Added a reminder in the release notes: "Reminder: Python 2 is not supported after 2019-12-31. PyStan will phase out testing of Python 2 after this point."