### PR TITLE
External C++

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -77,7 +77,7 @@ a number of methods.
       the rest for the parameters. Parameters are listed in the same order as `pars`.
 
    .. py:method:: stansummary(pars=None, probs=(0.025, 0.25, 0.5, 0.75, 0.975), digits_summary=2)
-   
+
       Summary statistic table.
       Parameters
       ----------
@@ -93,23 +93,23 @@ a number of methods.
          Table includes mean, se_mean, sd, probs_0, ..., probs_n, n_eff and Rhat.
       Examples
       --------
-      >>> model_code = 'parameters {real y;} model {y ~ normal(0,1);}'  
-      >>> m = StanModel(model_code=model_code, model_name="example_model")  
-      >>> fit = m.sampling()  
-      >>> print(fit.stansummary())  
-      Inference for Stan model: example_model.  
-      4 chains, each with iter=2000; warmup=1000; thin=1;  
-      post-warmup draws per chain=1000, total post-warmup draws=4000.  
-             mean se_mean     sd   2.5%    25%    50%    75%  97.5%  n_eff   Rhat  
-      y      0.01    0.03    1.0  -2.01  -0.68   0.02   0.72   1.97   1330    1.0  
-      lp__   -0.5    0.02   0.68  -2.44  -0.66  -0.24  -0.05-5.5e-4   1555    1.0  
-      Samples were drawn using NUTS at Thu Aug 17 00:52:25 2017.  
-      For each parameter, n_eff is a crude measure of effective sample size,  
-      and Rhat is the potential scale reduction factor on split chains (at  
+      >>> model_code = 'parameters {real y;} model {y ~ normal(0,1);}'
+      >>> m = StanModel(model_code=model_code, model_name="example_model")
+      >>> fit = m.sampling()
+      >>> print(fit.stansummary())
+      Inference for Stan model: example_model.
+      4 chains, each with iter=2000; warmup=1000; thin=1;
+      post-warmup draws per chain=1000, total post-warmup draws=4000.
+             mean se_mean     sd   2.5%    25%    50%    75%  97.5%  n_eff   Rhat
+      y      0.01    0.03    1.0  -2.01  -0.68   0.02   0.72   1.97   1330    1.0
+      lp__   -0.5    0.02   0.68  -2.44  -0.66  -0.24  -0.05-5.5e-4   1555    1.0
+      Samples were drawn using NUTS at Thu Aug 17 00:52:25 2017.
+      For each parameter, n_eff is a crude measure of effective sample size,
+      and Rhat is the potential scale reduction factor on split chains (at
       convergence, Rhat=1).
 
    .. py:method:: summary(pars=None, probs=None)
-      
+
       Summarize samples (compute mean, SD, quantiles) in all chains.
       REF: stanfit-class.R summary method
       Parameters
@@ -211,11 +211,11 @@ a number of methods.
           column for mean lp__ is also included.
 
    .. py:method:: constrain_pars(np.ndarray[double, ndim=1, mode="c"] upar not None)
-      
+
       Transform parameters from unconstrained space to defined support
-   
+
    .. py:method:: unconstrain_pars(par)
-       
+
       Transform parameters from defined support to unconstrained space
 
    .. py:method:: get_seed()
@@ -223,9 +223,9 @@ a number of methods.
    .. py:method:: get_inits()
 
    .. py:method:: get_stancode()
-   
+
    .. py:property:: flatnames
-   
+
    .. py:method:: to_dataframe(pars=None, permuted=True, dtypes=None, inc_warmup=False, diagnostics=True)
 
       Extract samples as a pandas datafriame for different parameters.
@@ -251,8 +251,8 @@ a number of methods.
       Returns
       -------
       df : pandas dataframe
-	
+
 	   Note
 	   ----
-	   Unlike default in extract (`permuted=True`) 
+	   Unlike default in extract (`permuted=True`)
 	   `.to_dataframe` method returns non-permuted samples (`permuted=False`) with diagnostics params included.

--- a/doc/external_cpp.rst
+++ b/doc/external_cpp.rst
@@ -14,15 +14,17 @@ gives more in-depth example using external C++.
 Setting up C++
 ==============
 
-Your C++ code either needs to provide needed gradients and partial derivatives
-to work properly. This can be done by manually coding each needed component,
-or using Stan's autodiff (special syntax).
+Your C++ code needs to provide needed gradients and partial derivatives to work
+properly. This can be done by manually implementing each needed component
+or by using Stan's autodiff (special syntax). Each function also needs to
+accept a ``std::ostream`` as a last argument.
 
 In the following instructions it is assumed that the first code is saved to
 a file called ``external_manual.hpp`` and ``external_autograd.hpp``. Both files
 are saved under ``cwd`` in a directory ``external_cpp``.
 
-The minimal example with manually coded gradients for a function ``C = A*B*B+A``:
+The following code shows a minimal example with manually implemented gradients
+for a function ``C = A*B*B+A``:
 
 .. code-block:: c++
 
@@ -134,4 +136,6 @@ is set to ``True``.
     fit = stan_model.sampling()
     print(fit)
 
-Compilation with external C++ can take longer than normally.
+Compilation with external C++ can take longer than normally. The external C++
+code is injected to the ``stanc`` translated C++ code. This injections is done
+automatically by PyStan before model compilation.

--- a/doc/external_cpp.rst
+++ b/doc/external_cpp.rst
@@ -1,0 +1,137 @@
+.. _external_cpp:
+
+.. currentmodule:: pystan
+
+======================================
+ External C++ (experimental)
+======================================
+
+This feature is experimental and nothing is guaranteed.
+
+Instructions follow loosely https://dfm.io/posts/stan-c++/ which
+gives more in-depth example using external C++.
+
+Setting up C++
+==============
+
+Your C++ code either needs to provide needed gradients and partial derivatives
+to work properly. This can be done by manually coding each needed component,
+or using Stan's autodiff (special syntax).
+
+In the following instructions it is assumed that the first code is saved to
+a file called ``external_manual.hpp`` and ``external_autograd.hpp``. Both files
+are saved under ``cwd`` in a directory ``external_cpp``.
+
+The minimal example with manually coded gradients for a function ``C = A*B*B+A``:
+
+.. code-block:: c++
+
+        inline double my_func (double A, double B, std::ostream* pstream) {
+          double C = A*B*B+A;
+
+          return C;
+        }
+
+        inline var my_func (const var& A_var, const var& B_var, std::ostream* pstream) {
+          // Compute the value
+          double A = A_var.val(),
+                 B = B_var.val(),
+                 C = my_func(A, B, pstream);
+
+          // Compute the partial derivatives:
+          double dC_dA = B*B+1.0,
+                 dC_dB = 2.0*A*B;
+
+          // Autodiff wrapper:
+          return var(new precomp_vv_vari(
+            C,             // The _value_ of the output
+            A_var.vi_,     // The input gradient wrt A
+            B_var.vi_,     // The input gradient wrt B
+            dC_dA,         // The partial introduced by this function wrt A
+            dC_dB          // The partial introduced by this function wrt B
+          ));
+        }
+
+        inline var my_func (double A, const var& B_var, std::ostream* pstream) {
+          double B = B_var.val(),
+                 C = my_func(A, B, pstream),
+                 dC_dB = 2.0*A*B;
+          return var(new precomp_v_vari(C, B_var.vi_, dC_dB));
+        }
+
+        inline var my_func (const var& A_var, double B, std::ostream* pstream) {
+          double A = A_var.val(),
+                 C = my_func(A, B, pstream),
+                 dC_dA = B*B+1.0;
+          return var(new precomp_v_vari(C, A_var.vi_, dC_dA));
+        }
+
+The minimal example using Stan´s autograd for a function ``C = A*B*B+A``:
+
+.. code-block:: c++
+
+        template <typename T1, typename T2>
+        typename boost::math::tools::promote_args<T1, T2>::type
+        my_other_func (const T1& A, const T2& B, std::ostream* pstream) {
+          typedef typename boost::math::tools::promote_args<T1, T2>::type T;
+
+          T C = A*B*B+A;
+
+          return C;
+        }
+
+Setting up Stan
+===============
+
+User needs to define functions inside a ``functions`` block. Function names
+are defined in the C++ code.
+
+.. code-block:: stan
+
+        functions {
+            real my_func(real A, real B);
+            real my_other_func(real A, real B);
+        }
+        data {
+            real B;
+        }
+        parameters {
+            real A;
+            real D;
+        }
+        transformed parameters {
+            real C = my_func(A, B);
+            real E = my_other_func(D, B);
+        }
+        model {
+            C ~ std_normal();
+            E ~ std_normal();
+        }
+
+Setting up Python
+=================
+In Python user needs information of location for external C++ code. This
+information is passed to ``StanModel`` with two ``list``-objects
+``include_dir`` and ``includes``. Also ``allow_undefined`` keyword
+is set to ``True``.
+
+.. code-block:: stan
+
+    import pystan
+    import os
+
+    model_code = """...
+                 """
+
+    include_dir = [os.path.join(".", "external_cpp")]
+    include_files = ["external_manual.hpp", "external_autograd.hpp"]
+    stan_model = pystan.StanModel(model_code=model_code,
+                                  verbose=True,
+                                  allow_undefined=True,
+                                  includes=include_files,
+                                  include_dirs=[include_dir],
+                                 )
+    fit = stan_model.sampling()
+    print(fit)
+
+Compilation with external C++ can take longer than normally.

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -30,6 +30,7 @@ Documentation
    logging
    threading_support
    windows
+   external_cpp
 
 Stan documentation
 ------------------

--- a/doc/installation_beginner.rst
+++ b/doc/installation_beginner.rst
@@ -12,6 +12,7 @@ Python and would benefit from additional guidance on how to install PyStan.
 Installing PyStan requires installing:
 
 -  Python
+-  C++ -compiler
 -  Python dependencies
 -  PyStan
 
@@ -20,7 +21,7 @@ Prerequisite knowledge
 
 It is highly recommended to know what ``bash`` is and the basics of
 navigating the terminal. You can review or learn it from the `Software
-Carpentry <http://software-carpentry.org/>`_ (`bash lesson here 
+Carpentry <http://software-carpentry.org/>`_ (`bash lesson here
 <http://swcarpentry.github.io/shell-novice/>`_).
 
 Lessons 1 - 3 are probably the most important.
@@ -92,6 +93,41 @@ to install them as such:
 -  open a terminal
 -  type ``conda install numpy`` to install numpy or replace ``numpy``
    with the package you need to install
+-  common additional packages include ``arviz``, ``matplotlib``, ``pandas``,
+   ``scipy``
+
+Setting up C++ compiler
+-----------------------
+
+PyStan 2.19+ needs a C++14 compatible compiler. For GCC 4.9.3+ and
+GCC 5+ versions are up-to-date. To update your compiler, follow general
+instructions given for each platform.
+
+-  Linux: Install compiler with ``apt``/``yum``
+-  Macs: Install latest XCode, or use ``brew`` or ``macports``
+-  Windows: Follow instructions in `PyStan on Windows <_windows>`_.
+
+To use ``gcc``/``clang`` compiler from the ``conda`` follow instructions in
+https://docs.conda.io/projects/conda-build/en/latest/resources/compiler-tools.html
+and set-up your ``CC`` environmental variable as given below. Instructions below
+assume default Anaconda environment. For ``conda-forge`` follow installation
+instructions in anaconda.org.
+
+-  open a terminal
+-  Linux: ``conda install gcc_linux-64 gxx_linux-64 -c anaconda``
+-  Macs: ``conda install clang_osx-64 clangxx_osx-64 -c anaconda``
+
+To check your compiler version
+
+- Open a terminal
+- type ``gcc --version``
+
+To use specific C++ compiler (``gcc_linux-64``), either update your ``CC`` environmental
+variable or set-up your path to include folder containing compiler
+(e.g.``which gcc_linux-64``)
+
+- type ``export CC=gcc_linux-64``
+- type ``export PATH=/path/to/Anaconda/bin:$PATH``
 
 Installing PyStan
 -----------------
@@ -99,5 +135,5 @@ Installing PyStan
 Since we have the ``numpy`` and ``cython`` dependencies we need, we can
 install the latest version of PyStan using ``pip``. To do so:
 
--  Open a terminal
+-  open a terminal
 -  type ``pip install pystan``

--- a/pystan/_api.pyx
+++ b/pystan/_api.pyx
@@ -6,11 +6,11 @@
 # This file is licensed under Version 3.0 of the GNU General Public
 # License. See LICENSE for a text of the license.
 #-----------------------------------------------------------------------------
+from libcpp cimport bool
 from pystan.stanc cimport PyStancResult, stanc as c_stanc
 from libcpp cimport bool
 from libcpp.string cimport string
 from libcpp.vector cimport vector
-
 
 def stanc(bytes model_stancode, bytes model_name,
           bool allow_undefined, bytes filename,

--- a/pystan/api.py
+++ b/pystan/api.py
@@ -141,9 +141,6 @@ def stanc(file=None, charset='utf-8', model_code=None, model_name="anon_model",
     include_paths = [os.path.join(path, "") for path in include_paths]
     include_paths_bytes = [path.encode('utf-8') for path in include_paths]
 
-    # set to False
-    allow_undefined = False
-
     if obfuscate_model_name:
         # Make the model name depend on the code.
         model_name = (

--- a/pystan/api.py
+++ b/pystan/api.py
@@ -18,7 +18,8 @@ logger = logging.getLogger('pystan')
 
 
 def stanc(file=None, charset='utf-8', model_code=None, model_name="anon_model",
-          include_paths=None, verbose=False, obfuscate_model_name=True):
+          include_paths=None, verbose=False, obfuscate_model_name=True,
+          allow_undefined=False):
     """Translate Stan model specification into C++ code.
 
     Parameters
@@ -54,6 +55,10 @@ def stanc(file=None, charset='utf-8', model_code=None, model_name="anon_model",
         unique by the insertion of randomly generated characters.
         Generally it is recommended that this parameter be left as True.
 
+    allow_undefined : boolean, False by default
+        If True, the C++ code can be written even if there are undefined
+        functions.
+
     Returns
     -------
     stanc_ret : dict
@@ -65,13 +70,13 @@ def stanc(file=None, charset='utf-8', model_code=None, model_name="anon_model",
     -----
     C++ reserved words and Stan reserved words may not be used for
     variable names; see the Stan User's Guide for a complete list.
-    
+
     The `#include` method follows a C/C++ syntax `#include foo/my_gp_funs.stan`.
     The method needs to be at the start of the row, no whitespace is allowed.
     After the included file no whitespace or comments are allowed.
     `pystan.experimental`(PyStan 2.18) has a `fix_include`-function to clean the `#include`
-    statements from the `model_code`. 
-    Example: 
+    statements from the `model_code`.
+    Example:
     `from pystan.experimental import fix_include`
     `model_code = fix_include(model_code)`
 
@@ -155,7 +160,7 @@ def stanc(file=None, charset='utf-8', model_code=None, model_name="anon_model",
         filename_bytes = os.path.split(file)[-1].encode('utf-8')
 
     result = pystan._api.stanc(model_code_bytes, model_name_bytes,
-                               allow_undefined, filename_bytes, 
+                               allow_undefined, filename_bytes,
                                include_paths_bytes,
                               )
     if result['status'] == -1:  # EXCEPTION_RC is -1
@@ -178,7 +183,7 @@ def stan(file=None, model_name="anon_model", model_code=None, fit=None,
          data=None, pars=None, chains=4, iter=2000, warmup=None, thin=1,
          init="random", seed=None, algorithm=None, control=None, sample_file=None,
          diagnostic_file=None, verbose=False, boost_lib=None, eigen_lib=None,
-         include_paths=None, n_jobs=-1, **kwargs):
+         include_paths=None, n_jobs=-1, allow_undefined=False, **kwargs):
     """Fit a model using Stan.
 
     The `pystan.stan` function was deprecated in version 2.17 and will be
@@ -327,6 +332,10 @@ def stan(file=None, model_name="anon_model", model_code=None, fit=None,
         Sample in parallel. If -1 all CPUs are used. If 1, no parallel
         computing code is used at all, which is useful for debugging.
 
+    allow_undefined : boolean, False by default
+        If True, the C++ code can be written even if there are undefined
+        functions.
+
     Returns
     -------
 
@@ -425,7 +434,8 @@ def stan(file=None, model_name="anon_model", model_code=None, fit=None,
         m = StanModel(file=file, model_name=model_name, model_code=model_code,
                       boost_lib=boost_lib, eigen_lib=eigen_lib,
                       include_paths=include_paths,
-                      obfuscate_model_name=obfuscate_model_name, verbose=verbose)
+                      obfuscate_model_name=obfuscate_model_name, verbose=verbose,
+                      allow_undefined=allow_undefined)
     # check that arguments in kwargs are valid
     valid_args = {"chain_id", "init_r", "test_grad", "append_samples", "enable_random_init",
                   "refresh", "control"}

--- a/pystan/model.py
+++ b/pystan/model.py
@@ -252,6 +252,9 @@ class StanModel:
         self.model_cppcode = stanc_ret['cppcode']
         self.model_include_paths = stanc_ret['include_paths']
 
+        if allow_undefined or include_dirs or includes:
+            logger.warning("External C++ interface is an experimental feature. Be careful.")
+
         msg = "COMPILING THE C++ CODE FOR MODEL {} NOW."
         logger.info(msg.format(self.model_name))
         if verbose:
@@ -272,6 +275,8 @@ class StanModel:
         pystan_dir = os.path.dirname(__file__)
         if include_dirs is None:
             include_dirs = []
+        elif not isinstance(include_dirs, list):
+            raise TypeError("'include_dirs' needs to be a list: type={}".format(type(include_dirs)))
         include_dirs += [
             lib_dir,
             pystan_dir,
@@ -287,7 +292,7 @@ class StanModel:
         if includes is not None:
             code = ""
             for fn in includes:
-                code += "#include \"{0}\"\n".format(fn)
+                code += '#include "{0}"\n'.format(fn)
             ind = self.model_cppcode.index("static int current_statement_begin__;")
             self.model_cppcode = "\n".join([
                 self.model_cppcode[:ind], code, self.model_cppcode[ind:]

--- a/pystan/model.py
+++ b/pystan/model.py
@@ -142,6 +142,14 @@ class StanModel:
         Indicates whether intermediate output should be piped to the console.
         This output may be useful for debugging.
 
+    allow_undefined : boolean, False by default
+        If True, the C++ code can be written even if there are undefined
+        functions.
+
+    includes : list, None by default
+        If not None, the elements of this list will be assumed to be the
+        names of custom C++ header files that should be included.
+
     kwargs : keyword arguments
         Additional arguments passed to `stanc`.
 
@@ -211,7 +219,8 @@ class StanModel:
     def __init__(self, file=None, charset='utf-8', model_name="anon_model",
                  model_code=None, stanc_ret=None, include_paths=None,
                  boost_lib=None, eigen_lib=None, verbose=False,
-                 obfuscate_model_name=True, extra_compile_args=None):
+                 obfuscate_model_name=True, extra_compile_args=None,
+                 allow_undefined=False, includes=None):
 
         if stanc_ret is None:
             stanc_ret = pystan.api.stanc(file=file,
@@ -220,7 +229,8 @@ class StanModel:
                                          model_name=model_name,
                                          verbose=verbose,
                                          include_paths=include_paths,
-                                         obfuscate_model_name=obfuscate_model_name)
+                                         obfuscate_model_name=obfuscate_model_name,
+                                         allow_undefined=allow_undefined)
 
         if not isinstance(stanc_ret, dict):
             raise ValueError("stanc_ret must be an object returned by stanc.")
@@ -268,6 +278,15 @@ class StanModel:
         ]
 
         model_cpp_file = os.path.join(lib_dir, self.model_cppname + '.hpp')
+        if includes is not None:
+            code = ""
+            for fn in includes:
+                code += "#include \"{0}\"\n".format(os.path.abspath(fn))
+            # ind = self.model_cppcode.index("class {0} : public prob_grad".format(self.model_cppname))
+            ind = self.model_cppcode.index("static int current_statement_begin__;")
+            self.model_cppcode = "\n".join([
+                self.model_cppcode[:ind], code, self.model_cppcode[ind:]
+            ])
         with io.open(model_cpp_file, 'w', encoding='utf-8') as outfile:
             outfile.write(self.model_cppcode)
 

--- a/pystan/model.py
+++ b/pystan/model.py
@@ -150,6 +150,10 @@ class StanModel:
         If not None, the elements of this list will be assumed to be the
         names of custom C++ header files that should be included.
 
+    include_dirs : list, None by default
+        If not None, the directories in this list are added to the search
+        path of the compiler.
+
     kwargs : keyword arguments
         Additional arguments passed to `stanc`.
 
@@ -220,7 +224,7 @@ class StanModel:
                  model_code=None, stanc_ret=None, include_paths=None,
                  boost_lib=None, eigen_lib=None, verbose=False,
                  obfuscate_model_name=True, extra_compile_args=None,
-                 allow_undefined=False, includes=None):
+                 allow_undefined=False, include_dirs=None, includes=None):
 
         if stanc_ret is None:
             stanc_ret = pystan.api.stanc(file=file,
@@ -266,7 +270,9 @@ class StanModel:
         self.module_name = 'stanfit4{}_{}'.format(self.model_name, nonce)
         lib_dir = tempfile.mkdtemp()
         pystan_dir = os.path.dirname(__file__)
-        include_dirs = [
+        if include_dirs is None:
+            include_dirs = []
+        include_dirs += [
             lib_dir,
             pystan_dir,
             os.path.join(pystan_dir, "stan", "src"),
@@ -281,8 +287,7 @@ class StanModel:
         if includes is not None:
             code = ""
             for fn in includes:
-                code += "#include \"{0}\"\n".format(os.path.abspath(fn))
-            # ind = self.model_cppcode.index("class {0} : public prob_grad".format(self.model_cppname))
+                code += "#include \"{0}\"\n".format(fn)
             ind = self.model_cppcode.index("static int current_statement_begin__;")
             self.model_cppcode = "\n".join([
                 self.model_cppcode[:ind], code, self.model_cppcode[ind:]

--- a/pystan/tests/test_external_cpp.py
+++ b/pystan/tests/test_external_cpp.py
@@ -65,9 +65,10 @@ class TestExternalCpp(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        with open("data/external_cpp.hpp", "w") as f:
+        include_dir = os.path.join(os.path.dirname(__file__), 'data')
+        with open(os.path.join(include_dir, "external_cpp.hpp"), "w") as f:
             f.write(external_cpp_code)
-        with open("data/external_autograd_cpp.hpp", "w") as f:
+        with open(os.path.join(include_dir, "external_autograd_cpp.hpp"), "w") as f:
             f.write(external_cpp_code_stan_autograd)
         model_code = """
         functions {
@@ -90,7 +91,6 @@ class TestExternalCpp(unittest.TestCase):
             E ~ normal(5,3);
         }
         """
-        include_dir = os.path.join(os.path.dirname(__file__), 'data')
         cls.model = pystan.StanModel(model_code=model_code,
                                      verbose=True,
                                      allow_undefined=True,
@@ -98,7 +98,6 @@ class TestExternalCpp(unittest.TestCase):
                                                "external_autograd_cpp.hpp"],
                                      include_dirs=[include_dir],
                                      )
-        #model = pystan.StanModel(model_code=model_code)
         cls.B = 4.0
         cls.fit = cls.model.sampling(data={"B" : cls.B}, iter=100, chains=2)
         os.remove("data/external_cpp.hpp")

--- a/pystan/tests/test_external_cpp.py
+++ b/pystan/tests/test_external_cpp.py
@@ -100,8 +100,8 @@ class TestExternalCpp(unittest.TestCase):
                                      )
         cls.B = 4.0
         cls.fit = cls.model.sampling(data={"B" : cls.B}, iter=100, chains=2)
-        os.remove("data/external_cpp.hpp")
-        os.remove("data/external_autograd_cpp.hpp")
+        os.remove(os.path.join(include_dir, "external_cpp.hpp"))
+        os.remove(os.path.join(include_dir, "external_autograd_cpp.hpp"))
 
     def test_external_cpp(self):
         A = self.fit["A"]

--- a/pystan/tests/test_external_cpp.py
+++ b/pystan/tests/test_external_cpp.py
@@ -1,0 +1,92 @@
+import unittest
+import numpy as np
+from numpy.testing import assert_array_equal
+import os
+import pystan
+
+# NOTE: This test is fragile because the default sampling algorithm used by Stan
+# may change in significant ways.
+
+external_cpp_code = """
+inline double my_func (double A, double B, std::ostream* pstream) {
+  double C = A*B*B+A;
+
+  return C;
+}
+
+inline var my_func (const var& A_var, const var& B_var, std::ostream* pstream) {
+  // Compute the value
+  double A = A_var.val(),
+         B = B_var.val(),
+         C = my_func(A, B, pstream);
+
+  // Compute the partial derivatives:
+  double dC_dA = B*B+1.0,
+         dC_dB = 2.0*A*B;
+
+  // Autodiff wrapper:
+  return var(new precomp_vv_vari(
+    C,             // The _value_ of the output
+    A_var.vi_,     // The input gradient wrt A
+    B_var.vi_,     // The input gradient wrt B
+    dC_dA,         // The partial introduced by this function wrt A
+    dC_dB          // The partial introduced by this function wrt B
+  ));
+}
+
+inline var my_func (double A, const var& B_var, std::ostream* pstream) {
+  double B = B_var.val(),
+         C = my_func(A, B, pstream),
+         dC_dB = 2.0*A*B;
+  return var(new precomp_v_vari(C, B_var.vi_, dC_dB));
+}
+
+inline var my_func (const var& A_var, double B, std::ostream* pstream) {
+  double A = A_var.val(),
+         C = my_func(A, B, pstream),
+         dC_dA = B*B+1.0;
+  return var(new precomp_v_vari(C, A_var.vi_, dC_dA));
+}
+"""
+
+class TestExternalCpp(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+
+        with open("data/external_cpp.hpp", "w") as f:
+            f.write(external_cpp_code)
+        model_code = """
+        functions {
+            real my_func(real A, real B);
+        }
+        data {
+            real B;
+        }
+        parameters {
+            real A;
+        }
+        transformed parameters {
+            real C = my_func(A, B);
+        }
+        model {
+            C ~ std_normal();
+        }
+        """
+        include_dir = os.path.join(os.path.dirname(__file__), 'data')
+        cls.model = pystan.StanModel(model_code=model_code,
+                                     verbose=True,
+                                     allow_undefined=True,
+                                     includes=["external_cpp.hpp"],
+                                     include_dirs=[include_dir],
+                                     )
+        #model = pystan.StanModel(model_code=model_code)
+        cls.B = 4.0
+        cls.fit = cls.model.sampling(data={"B" : cls.B}, iter=100, chains=2)
+        os.remove("data/external_cpp.hpp")
+
+    def test_external_cpp(self):
+        A = self.fit["A"]
+        B = self.B
+        C = self.fit["C"]
+        assert_array_equal(C, A * B * B + A)


### PR DESCRIPTION
#### Summary:

Allow external C++ in Stan program.
If used, a warning is shown that this is an experimental feature.

#### Intended Effect:

Enable external C++ code.

#### How to Verify:

Run example e.g. https://dfm.io/posts/stan-c++/

#### Side Effects:

If not explicitly used, none.

#### Documentation:

Needs update.

#### Reviewer Suggestions: 

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

@dfm

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: GPLv3 (http://opensource.org/licenses/GPL-3.0)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
