### PR TITLE
Fix typos in optimization method

### DIFF
--- a/pystan/model.py
+++ b/pystan/model.py
@@ -479,15 +479,17 @@ class StanModel:
         save_iterations : bool, optional
         refresh : int, optional
         init_alpha : float, optional
-            For BFGS and LBFGS, default is 0.001
+            For BFGS and LBFGS, default is 0.001.
         tol_obj : float, optional
             For BFGS and LBFGS, default is 1e-12.
+        tol_rel_obj : int, optional
+            For BFGS and LBFGS, default is 1e4.
         tol_grad : float, optional
-            For BFGS and LBFGS, default is 1e-8.
-        tol_param : float, optional
             For BFGS and LBFGS, default is 1e-8.
         tol_rel_grad : float, optional
             For BFGS and LBFGS, default is 1e7.
+        tol_param : float, optional
+            For BFGS and LBFGS, default is 1e-8.
         history_size : int, optional
             For LBFGS, default is 5.
 

--- a/pystan/model.py
+++ b/pystan/model.py
@@ -534,7 +534,7 @@ class StanModel:
             stan_args['sample_file'] = pystan.misc._writable_sample_file(sample_file)
 
         # check that arguments in kwargs are valid
-        valid_args = {"iter", "save_iterations", "save_iterations", "refresh",
+        valid_args = {"iter", "save_iterations", "refresh",
                       "init_alpha", "tol_obj", "tol_grad", "tol_param",
                       "tol_rel_obj", "tol_rel_grad", "history_size"}
         for arg in kwargs:


### PR DESCRIPTION
#### Summary:

Fix a few typos in the optimization method. Also added the tol_rel_obj keyword arg and reordered the keyword args in the optimization method doc to match the order given by ```cmdstan```

#### Intended Effect:

Clearer documentation

#### How to Verify:

Should have no functional effects

#### Side Effects:

^^^

#### Documentation:

#### Reviewer Suggestions: 

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: GPLv3 (http://opensource.org/licenses/GPL-3.0)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
