### PR TITLE
Ignore optimization errors and return results anyways

### DIFF
--- a/pystan/model.py
+++ b/pystan/model.py
@@ -459,7 +459,7 @@ class StanModel:
 
         as_vector : boolean, optional
             Indicates an OrderedDict will be returned rather than a nested
-            dictionary with keys 'par' and 'value'.
+            dictionary with keys 'par', 'value', and 'ret'.
 
         Returns
         -------
@@ -547,10 +547,10 @@ class StanModel:
         stan_args.update(kwargs)
         stan_args = pystan.misc._get_valid_stan_args(stan_args)
 
-        ret, sample = fit._call_sampler(stan_args)
+        ret, sample, error = fit._call_sampler(stan_args)
         pars = pystan.misc._par_vector2dict(sample['par'], m_pars, p_dims)
         if not as_vector:
-            return OrderedDict([('par', pars), ('value', sample['value'])])
+            return OrderedDict([('par', pars), ('value', sample['value']), ('ret', ret), ('error', error)])
         else:
             return pars
 

--- a/pystan/model.py
+++ b/pystan/model.py
@@ -563,6 +563,8 @@ class StanModel:
         if not as_vector:
             return OrderedDict([('par', pars), ('value', sample['value']), ('ret', ret), ('error', sampler_error)])
         else:
+            # Add return and error codes to this ordered dict
+            pars.update({'__stan_return_code': ret, '__stan_error': sampler_error})
             return pars
 
     def sampling(self, data=None, pars=None, chains=4, iter=2000,

--- a/pystan/stanfit4model.pyx
+++ b/pystan/stanfit4model.pyx
@@ -401,7 +401,13 @@ def _call_sampler(data, args, pars_oi=None):
         pars_oi_bytes = [n.encode('ascii') for n in pars_oi]
         if len(pars_oi_bytes) != fitptr.param_names_oi().size():
             fitptr.update_param_oi(pars_oi_bytes)
-    ret = fitptr.call_sampler(deref(argsptr), deref(holderptr))
+
+    # Print any runtime exception but don't crash out
+    try:
+        ret = fitptr.call_sampler(deref(argsptr), deref(holderptr))
+    except RuntimeError as e:
+        print('{}: {}'.format(type(e).__name__, str(e)))
+
     holder = _pystanholder_from_stanholder(holderptr)
     # FIXME: rather than fetching the args from the holderptr, we just use
     # the argsptr we passed directly. This is a hack to solve a problem

--- a/pystan/stanfit4model.pyx
+++ b/pystan/stanfit4model.pyx
@@ -403,10 +403,13 @@ def _call_sampler(data, args, pars_oi=None):
             fitptr.update_param_oi(pars_oi_bytes)
 
     # Print any runtime exception but don't crash out
+    call_sampler_error = None
+    ret = 0
     try:
         ret = fitptr.call_sampler(deref(argsptr), deref(holderptr))
     except RuntimeError as e:
         print('{}: {}'.format(type(e).__name__, str(e)))
+        call_sampler_error = e
 
     holder = _pystanholder_from_stanholder(holderptr)
     # FIXME: rather than fetching the args from the holderptr, we just use
@@ -415,7 +418,7 @@ def _call_sampler(data, args, pars_oi=None):
     holder.args = _dict_from_stanargs(argsptr)
     del argsptr
     del fitptr
-    return ret, holder
+    return ret, holder, call_sampler_error
 
 def _split_pars_locs(fnames, pars):
     """Split flatnames to par and location"""


### PR DESCRIPTION
#### Summary:

So in ```rstan``` when the ```optimizing``` function errors out it still returns the parameters at the last iteration before the error -- and right now this behavior isn't implemented in ```pystan``` (it throws a runtime error that has to be caught). This change returns parameters from the optimization call regardless of the outcome.

#### Intended Effect:

Get parity with the error behavior of ```optimizing``` in ```rstan```.

#### How to Verify:

Run ```pystan``` with a model/data that fails, and check if you get the parameters returned.

#### Side Effects:

This change will probably make it harder for new users to debug and understand their models, but having this behavior is good for optimization runs that error out simply because the tolerances are not set correctly. Instead of putting the burden on the users to change hyperparameters and re-run what could potentially be a very long computational run -- users can use the returned parameters which could work perfectly well for their purposes.

#### Documentation:

#### Reviewer Suggestions: 

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: GPLv3 (http://opensource.org/licenses/GPL-3.0)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
