### PR TITLE
ci: Correct wheel uploader key appveyor

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -8,7 +8,7 @@ environment:
     WHEELHOUSE_UPLOADER_REGION: IAD
     WHEELHOUSE_UPLOADER_USERNAME: pystan-worker
     WHEELHOUSE_UPLOADER_SECRET:
-      secure: cqdCOlelH3UdBVv+FyD4nNfT5X5bB2OwqehwkxqMABKcHy1H4+t8v3jVVvTxV7uq
+      secure: mjwuqrrrl71BQoPg5t++MKlVApmBBDAr7GmQtI5YawjhdpCJtMi+Tof4P1ENDCLp
 
   matrix:
     - CONDA: 27
@@ -76,7 +76,7 @@ install:
 
   - ECHO "Starting to build the wheel"
   # build the wheel and install it
-  - python setup.py --quiet bdist_wheel bdist_wininst
+  - python setup.py --quiet bdist_wheel
   - ps: "ls dist"
 
   - ECHO "Install generated wheel to test it"


### PR DESCRIPTION
This also removes `bdist_wininst` (which generates files like `pystan-2.19.0.0.win-amd64-py3.5.exe`). My sense is that nobody uses these.