### PR TITLE
fix: Fix appveyor link in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -144,9 +144,10 @@ Example
     :target: https://travis-ci.org/stan-dev/pystan
     :alt: travis-ci build status
 
-.. |appveyor| image:: https://ci.appveyor.com/api/projects/status/github/stan-dev/pystan?branch=master
-    :target: https://ci.appveyor.com/project/pystan/pystan/branch/master
+.. |appveyor| image:: https://ci.appveyor.com/api/projects/status/49e69yl5ngxkpmab?svg=true
+    :target: https://ci.appveyor.com/project/pystan/pystan
     :alt: appveyor-ci build status
+
 .. |zenodo| image:: https://zenodo.org/badge/10256919.svg
     :target: https://zenodo.org/badge/latestdoi/10256919
     :alt: zenodo citation DOI 


### PR DESCRIPTION
Closes #604.

The appveyor docs seem to suggest a slightly different url. I gather it's pending because we have not built the `master` branch on this appveyor account. I suspect it will fix itself when we have the next release.