### PR TITLE
Load pickled fit without the model instance

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -31,6 +31,7 @@ Documentation
    threading_support
    windows
    external_cpp
+   unpickling_fit_without_model
 
 Stan documentation
 ------------------

--- a/doc/unpickling_fit_without_model.rst
+++ b/doc/unpickling_fit_without_model.rst
@@ -1,0 +1,67 @@
+.. _unpickling_fit_without_model:
+
+.. currentmodule:: pystan
+
+=====================================================
+ Unpickling fit without Model instance (experimental)
+=====================================================
+
+This feature is experimental and nothing is guaranteed.
+
+In PyStan it is needed to import model instance before unpickling the fit object.
+This is commonly done by pickling model instance and fit object together in an object
+that keeps the order (``list``, ``tuple``, ``OrderedDict``, ``dict`` with python 3.6+).
+
+Sometimes mistakes are done, and fit objects are pickled without the model instance,
+and there is no way to reload the model from other pickled files. Rebuilding the model
+from Stan-code does not work in this case, because the module name contains random parts
+that are decided at the runtime.
+To still get data and samples saved to fit object, PyStan has ``unpickle_fit`` -function
+in its experimental submodule. The function will create a fake ``StanModel`` instance
+with the correct module name, which enables one to unpickle fit object without the
+original model instance. This means, that the model object should not be used to
+anything which includes the functionality wrapped in the fit object.
+
+The suggested use of this feature is to enable users to extract samples with
+``.extract()`` method (and access other information stored to ``fit.sim`` object).
+After extraction it is recommended to save samples in another format, such as
+``dict`` , netCDF4 (``arviz.InferenceData``) or tabular format (``pandas.DataFrame``).
+
+Example
+=======
+
+Following example will show how to unpickle fit object without model instance and
+save the resulting samples in other formats.
+
+.. code-block:: python
+
+    import pystan
+    import pystan.experimental
+
+    path = "path/to/fit.pickle"
+    fit = pystan.experimental.unpickle_fit(path)
+
+Example on how to save extracted samples to with pickle
+
+.. code-block:: python
+
+    import pickle
+    with open("path/to/fit_dict.pickle", "wb") as f:
+        pickle.dump(fit.extract(), protocol=pickle.HIGHEST_PROTOCOL)
+
+Example on how to save extracted samples + other information with ArviZ to netCDF4.
+
+.. code-block:: python
+
+    import arviz as az
+    # for more advanced function use, see https://arviz-devs.github.io/arviz/generated/arviz.from_pystan.html
+    idata = az.from_pystan(fit)
+    idata.to_netcdf("path/to/fit.nc")
+
+Example on how to save extracted samples to csv with pandas
+
+.. code-block:: python
+
+    # using pystan.misc.to_dataframe -function works also with the older fit objects
+    df = pystan.misc.to_dataframe(fit)
+    df.to_csv("path/to/fit.csv", index=False)

--- a/pystan/experimental/__init__.py
+++ b/pystan/experimental/__init__.py
@@ -1,6 +1,7 @@
-import logging
-from .misc import *
+import logging as _logging
+from .misc import fix_include
+from .pickling_tools import load_fit
 
-logger = logging.getLogger('pystan')
+_logger = _logging.getLogger('pystan')
 
-logger.warning("This submodule contains experimental code, please use with caution")
+_logger.warning("This submodule contains experimental code, please use with caution")

--- a/pystan/experimental/__init__.py
+++ b/pystan/experimental/__init__.py
@@ -1,7 +1,5 @@
-import logging as _logging
+import logging
 from .misc import fix_include
 from .pickling_tools import load_fit
 
-_logger = _logging.getLogger('pystan')
-
-_logger.warning("This submodule contains experimental code, please use with caution")
+logging.getLogger('pystan').warning("This submodule contains experimental code, please use with caution")

--- a/pystan/experimental/__init__.py
+++ b/pystan/experimental/__init__.py
@@ -1,5 +1,6 @@
 import logging
 from .misc import fix_include
-from .pickling_tools import load_fit
+from .pickling_tools import unpickle_fit
 
-logging.getLogger('pystan').warning("This submodule contains experimental code, please use with caution")
+logger = logging.getLogger('pystan')
+logger.warning("This submodule contains experimental code, please use with caution")

--- a/pystan/experimental/pickling_tools.py
+++ b/pystan/experimental/pickling_tools.py
@@ -171,7 +171,7 @@ def get_module_name(path, open_func=None, open_kwargs=None):
     return module_name
 
 
-def load_fit(path, open_func=None, open_kwargs=None, module_name=None, return_model=False):
+def unpickle_fit(path, open_func=None, open_kwargs=None, module_name=None, return_model=False):
     """Load pickled (compressed) fit object without model binary.
 
     Parameters

--- a/pystan/experimental/pickling_tools.py
+++ b/pystan/experimental/pickling_tools.py
@@ -1,0 +1,226 @@
+"""Experimental module to load fit without model instance."""
+from distutils.core import Extension
+from Cython.Build.Inline import _get_build_extension
+from Cython.Build.Dependencies import cythonize
+import tempfile
+import logging
+import io
+import os
+import string
+import numpy as np
+import pickle
+import pystan
+import platform
+from string import ascii_letters, digits, printable, punctuation
+import sys
+import shutil
+
+from pystan.model import load_module
+
+def create_fake_model(module_name):
+    """Creates a fake model with specific module name.
+
+    Parameters
+    ----------
+    module_name : str
+
+    Returns
+    -------
+    StanModel
+        Dummy StanModel object with specific module name.
+    """
+    # reverse engineer the name
+    model_name, nonce = module_name.replace("stanfit4", "").rsplit("_", 1)
+    # create minimal code
+    model_code = """generated quantities {real fake_parameter=1;}"""
+    stanc_ret = pystan.api.stanc(model_code=model_code,
+                                 model_name=model_name,
+                                 obfuscate_model_name=False)
+
+    model_cppname = stanc_ret['model_cppname']
+    model_cppcode = stanc_ret['cppcode']
+
+    original_module_name = module_name
+    module_name = 'stanfit4{}_{}'.format(model_name, nonce)
+    # module name should be same
+    assert original_module_name == module_name
+
+
+    lib_dir = tempfile.mkdtemp()
+    pystan_dir = os.path.dirname(pystan.__file__)
+    include_dirs = [
+        lib_dir,
+        pystan_dir,
+        os.path.join(pystan_dir, "stan", "src"),
+        os.path.join(pystan_dir, "stan", "lib", "stan_math"),
+        os.path.join(pystan_dir, "stan", "lib", "stan_math", "lib", "eigen_3.3.3"),
+        os.path.join(pystan_dir, "stan", "lib", "stan_math", "lib", "boost_1.69.0"),
+        os.path.join(pystan_dir, "stan", "lib", "stan_math", "lib", "sundials_4.1.0", "include"),
+        np.get_include(),
+    ]
+
+    model_cpp_file = os.path.join(lib_dir, model_cppname + '.hpp')
+
+    with io.open(model_cpp_file, 'w', encoding='utf-8') as outfile:
+        outfile.write(model_cppcode)
+
+    pyx_file = os.path.join(lib_dir, module_name + '.pyx')
+    pyx_template_file = os.path.join(pystan_dir, 'stanfit4model.pyx')
+    with io.open(pyx_template_file, 'r', encoding='utf-8') as infile:
+        s = infile.read()
+        template = string.Template(s)
+    with io.open(pyx_file, 'w', encoding='utf-8') as outfile:
+        s = template.safe_substitute(model_cppname=model_cppname)
+        outfile.write(s)
+
+    stan_macros = [
+        ('BOOST_RESULT_OF_USE_TR1', None),
+        ('BOOST_NO_DECLTYPE', None),
+        ('BOOST_DISABLE_ASSERTS', None),
+    ]
+
+    build_extension = _get_build_extension()
+
+    extra_compile_args = []
+
+    if platform.platform().startswith('Win'):
+        if build_extension.compiler in (None, 'msvc'):
+            logger.warning("MSVC compiler is not supported")
+            extra_compile_args = [
+                '/EHsc',
+                '-DBOOST_DATE_TIME_NO_LIB',
+                '/std:c++14',
+            ] + extra_compile_args
+        else:
+            # Windows, but not msvc, likely mingw
+            # fix bug in MingW-W64
+            # use posix threads
+            extra_compile_args = [
+                '-O1',
+                '-ftemplate-depth-256',
+                '-Wno-unused-function',
+                '-Wno-uninitialized',
+                '-std=c++1y',
+                "-D_hypot=hypot",
+                "-pthread",
+                "-fexceptions",
+            ] + extra_compile_args
+    else:
+        # linux or macOS
+        extra_compile_args = [
+            '-O1',
+            '-ftemplate-depth-256',
+            '-Wno-unused-function',
+            '-Wno-uninitialized',
+            '-std=c++1y',
+        ] + extra_compile_args
+
+    extension = Extension(name=module_name,
+                          language="c++",
+                          sources=[pyx_file],
+                          define_macros=stan_macros,
+                          include_dirs=include_dirs,
+                          extra_compile_args=extra_compile_args)
+
+    cython_include_dirs = ['.', pystan_dir]
+
+    build_extension.extensions = cythonize([extension],
+                                           include_path=cython_include_dirs,
+                                           quiet=True)
+    build_extension.build_temp = os.path.dirname(pyx_file)
+    build_extension.build_lib = lib_dir
+
+    build_extension.run()
+
+
+    module = load_module(module_name, lib_dir)
+
+    shutil.rmtree(lib_dir, ignore_errors=True)
+    return module
+
+
+def get_module_name(path, open_func=None, open_kwargs=None):
+    if open_func is None:
+        open_func = io.open
+    if open_kwargs is None:
+        open_kwargs = {"mode" : "rb"}
+
+    valid_chr = digits + ascii_letters + punctuation
+    break_next = False
+    name_loc = False
+    module_name = ""
+    with open_func(path, **open_kwargs) as f:
+        # scan first few bytes
+        for i in range(500):
+            byte, = f.read(1)
+            if name_loc and chr(byte) in valid_chr:
+                module_name += chr(byte)
+
+                if module_name == "stanfit":
+                    break_next = True
+            elif chr(byte) == "s":
+                module_name += chr(byte)
+                name_loc = True
+            elif break_next:
+                break
+    return module_name
+
+
+def load_fit(path, open_func=None, open_kwargs=None, module_name=None, return_model=False):
+    """Load pickled (compressed) fit object without model binary.
+
+    Parameters
+    ----------
+    path : str
+    open_func : function
+        Function that takes path and returns fileobject. E.g. `io.open`, `gzip.open`.
+    open_kwargs : dict
+        Keyword arguments for `open_func`.
+    module_name : str, optional
+        Module name used for the StanModel. By default module name is extractad from pickled file.
+    return_model : bool
+        Return the fake model.
+        WARNING: Model should not be used for anything.
+
+    Returns
+    -------
+    StanFit4Model
+    StanModel, optional
+
+    Examples
+    --------
+    >>> import pystan
+    >>> import pystan.experimental
+    >>> path = "path/to/fit.pickle"
+    >>> fit = pystan.experimental.load_fit(path)
+
+    Save fit to external format
+
+    Transform fit to dataframe and save to csv
+    >>> df = pystan.misc.to_dataframe(fit)
+    >>> df.to_csv("path/to/fit.csv")
+
+    Transform fit to arviz.InferenceData and save to netCDF4
+    >>> import arviz as az
+    >>> idata = az.from_pystan(fit)
+    >>> idata.to_netcdf("path/to/fit.nc")
+    """
+    if module_name is None:
+        module_name = get_module_name(path, open_func, open_kwargs)
+    if not module_name:
+        raise ValueError("Module name not found")
+
+    # create fake model
+    model = create_fake_model(module_name)
+
+    if open_func is None:
+        open_func = io.open
+    if open_kwargs is None:
+        open_kwargs = {"mode":"rb"}
+
+    with open_func(path, **open_kwargs) as f:
+        fit = pickle.load(f)
+    if return_model:
+        logger.warning("The model binary is built against fake model code. Model should not be used.")
+        return fit, model
+    return fit

--- a/pystan/experimental/pickling_tools.py
+++ b/pystan/experimental/pickling_tools.py
@@ -15,7 +15,10 @@ from string import ascii_letters, digits, printable, punctuation
 import sys
 import shutil
 
+from pystan._compat import PY2
 from pystan.model import load_module
+
+logger = logging.getLogger('pystan')
 
 def create_fake_model(module_name):
     """Creates a fake model with specific module name.
@@ -153,13 +156,15 @@ def get_module_name(path, open_func=None, open_kwargs=None):
         # scan first few bytes
         for i in range(500):
             byte, = f.read(1)
-            if name_loc and chr(byte) in valid_chr:
-                module_name += chr(byte)
+            if not PY2:
+                byte = chr(byte)
+            if name_loc and byte in valid_chr:
+                module_name += byte
 
                 if module_name == "stanfit":
                     break_next = True
-            elif chr(byte) == "s":
-                module_name += chr(byte)
+            elif byte == "s":
+                module_name += byte
                 name_loc = True
             elif break_next:
                 break

--- a/pystan/tests/test_pickle.py
+++ b/pystan/tests/test_pickle.py
@@ -4,6 +4,7 @@ import pickle
 import sys
 import tempfile
 import unittest
+import numpy as np
 
 import pystan
 from pystan.tests.helper import get_model
@@ -89,7 +90,7 @@ class TestPickle(unittest.TestCase):
         model1 = pystan.StanModel(model_code=model_code, model_name="normal1")
         model2 = pystan.StanModel(model_code=model_code, model_name="normal1")
         self.assertNotEqual(model1.module_name, model2.module_name)
-  
+
 class TestPickleFitOnly(unittest.TestCase):
 
     @classmethod
@@ -104,10 +105,10 @@ class TestPickleFitOnly(unittest.TestCase):
         cls.pickle_extract = os.path.join(tempfolder, 'stanextract.pkl')
         with io.open(cls.pickle_fit, mode="wb") as f:
             pickle.dump(fit, f)
-        
+
         with io.open(cls.pickle_extract, mode="wb") as f:
             pickle.dump(fit.extract(), f)
-        
+
         module_name = model.module.__name__
         del model
         del sys.modules[module_name]
@@ -116,14 +117,14 @@ class TestPickleFitOnly(unittest.TestCase):
     def test_load_fit_fail(self):
         with io.open(self.pickle_file, "rb") as f:
             pickle.load(f)
-   
+
     def test_load_fit(self):
         fit, model = load_fit(self.pickle_fit, open_func=io.open, open_kwargs={"mode" : "rb"}, return_model=True)
         self.assertIsNotNone(fit)
         self.assertIsNotNone(model)
         self.assertIsNotNone(fit.extract())
         self.assertTrue("y" in fit.extract())
-        
+
         with io.open(self.pickle_extract, "rb") as f:
             extract = pickle.load(f)
-        self.assertEqual(fit.extract(), extract)
+        self.assertTrue(np.all(fit.extract()["y"] == extract["y"]))

--- a/pystan/tests/test_pickle.py
+++ b/pystan/tests/test_pickle.py
@@ -1,3 +1,4 @@
+import io
 import os
 import pickle
 import sys
@@ -5,7 +6,8 @@ import tempfile
 import unittest
 
 import pystan
-
+from pystan.tests.helper import get_model
+from pystan.experimental import load_fit
 
 class TestPickle(unittest.TestCase):
 
@@ -87,3 +89,41 @@ class TestPickle(unittest.TestCase):
         model1 = pystan.StanModel(model_code=model_code, model_name="normal1")
         model2 = pystan.StanModel(model_code=model_code, model_name="normal1")
         self.assertNotEqual(model1.module_name, model2.module_name)
+  
+class TestPickleFitOnly(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        model_code = 'parameters {real y;} model {y ~ normal(0,1);}'
+        model = get_model("standard_normal_model",
+                          model_code, model_name="normal1",
+                          verbose=True, obfuscate_model_name=False)
+        fit = model.sampling()
+        tempfolder = tempfile.mkdtemp()
+        cls.pickle_fit = os.path.join(tempfolder, 'stanfit.pkl')
+        cls.pickle_extract = os.path.join(tempfolder, 'stanextract.pkl')
+        with io.open(cls.pickle_fit, mode="wb") as f:
+            pickle.dump(fit, f)
+        
+        with io.open(cls.pickle_extract, mode="wb") as f:
+            pickle.dump(fit.extract(), f)
+        
+        module_name = model.module.__name__
+        del model
+        del sys.modules[module_name]
+
+    @unittest.expectedFailure
+    def test_load_fit_fail(self):
+        with io.open(self.pickle_file, "rb") as f:
+            pickle.load(f)
+   
+    def test_load_fit(self):
+        fit, model = load_fit(self.pickle_fit, open_func=io.open, open_kwargs={"mode" : "rb"}, return_model=True)
+        self.assertIsNotNone(fit)
+        self.assertIsNotNone(model)
+        self.assertIsNotNone(fit.extract())
+        self.assertTrue("y" in fit.extract())
+        
+        with io.open(self.pickle_extract, "rb") as f:
+            extract = pickle.load(f)
+        self.assertEqual(fit.extract(), extract)

--- a/pystan/tests/test_pickle.py
+++ b/pystan/tests/test_pickle.py
@@ -8,7 +8,7 @@ import numpy as np
 
 import pystan
 from pystan.tests.helper import get_model
-from pystan.experimental import load_fit
+from pystan.experimental import unpickle_fit
 
 class TestPickle(unittest.TestCase):
 
@@ -114,12 +114,12 @@ class TestPickleFitOnly(unittest.TestCase):
         del sys.modules[module_name]
 
     @unittest.expectedFailure
-    def test_load_fit_fail(self):
+    def test_unpickle_fit_fail(self):
         with io.open(self.pickle_file, "rb") as f:
             pickle.load(f)
 
     def test_load_fit(self):
-        fit, model = load_fit(self.pickle_fit, open_func=io.open, open_kwargs={"mode" : "rb"}, return_model=True)
+        fit, model = unpickle_fit(self.pickle_fit, open_func=io.open, open_kwargs={"mode" : "rb"}, return_model=True)
         self.assertIsNotNone(fit)
         self.assertIsNotNone(model)
         self.assertIsNotNone(fit.extract())


### PR DESCRIPTION
#### Summary:

Add functionality to read old fit files, without the correct model instance.

#### Intended Effect:

Read fit, which doesn't have model instance saved.

#### How to Verify:

1. create a fit 
2. pickle only the fit
3. restart python
4. try to load pickle normally
5. load pickle with `pystan.experimental.load_fit`

tests added
~@riddell-stan do you want to add tests for experimental code too?~

#### Side Effects:

None. This is inside experimental module, which is not imported by default.

#### Documentation:

Needs update and simple example. Also needs to have disclaimer, that probably only works with the
original OS. (I have not tested with other OS, so let's test before merge).

#### Reviewer Suggestions: 

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Ari Hartikainen

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: GPLv3 (http://opensource.org/licenses/GPL-3.0)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
