### PR TITLE
Use prefix `pystan_` with tempfolder

### DIFF
--- a/pystan/model.py
+++ b/pystan/model.py
@@ -271,7 +271,7 @@ class StanModel:
         # module_name needs to be unique so that each model instance has its own module
         nonce = abs(hash((self.model_name, time.time())))
         self.module_name = 'stanfit4{}_{}'.format(self.model_name, nonce)
-        lib_dir = tempfile.mkdtemp()
+        lib_dir = tempfile.mkdtemp(prefix='pystan_')
         pystan_dir = os.path.dirname(__file__)
         if include_dirs is None:
             include_dirs = []


### PR DESCRIPTION
#### Summary:

On Windows, temp files are not removed. This makes it easier to remove pystan specific files if a user wants to do that.

#### Intended Effect:

change tempfolder name from `tmp...` to `pystan_...`

#### How to Verify:

Create a model and see the tempfolder name.

#### Side Effects:

None (longer path, but the difference is minimal)

#### Documentation:

#### Reviewer Suggestions: 

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Ari Hartikainen

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: GPLv3 (http://opensource.org/licenses/GPL-3.0)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
