### PR TITLE
bugfix - fit.__repr__

### DIFF
--- a/pystan/stanfit4model.pyx
+++ b/pystan/stanfit4model.pyx
@@ -670,9 +670,9 @@ cdef class StanFit4Model:
             update = len(self._repr_pars)-1 != self._repr_num
         if self._repr_pars is not None and not update:
             return self._repr_pars
-        elif len(self.flatnames) > self._repr_num:
+        elif len(self.sim["fnames_oi"]) > self._repr_num:
             logger.warning("Truncated summary with the 'fit.__repr__' method. For the full summary use 'print(fit)'")
-            self._set_repr_pars(self.flatnames[:self._repr_num-1] + ['lp__'])
+            self._set_repr_pars(self.sim["fnames_oi"][:self._repr_num-1] + ['lp__'])
             return self._repr_pars
 
     def _set_repr_num(self, n):
@@ -683,7 +683,7 @@ cdef class StanFit4Model:
 
     def __repr__(self):
         pars = self._get_repr_pars()
-        if pars is not None and len(self.flatnames) > len(pars):
+        if pars is not None and len(self.sim["fnames_oi"]) > len(pars):
             s = "\nWarning: Shown data is truncated to {} parameters".format(len(pars))
             s += "\nFor the full summary use 'print(fit)'\n\n"
             s += pystan.misc.stansummary(self, pars=pars)


### PR DESCRIPTION
Fixes #641 

#### Summary:

Fix error if fit contains subset of the parameters.

Changes fit.flatnames to fit.sim["fnames_oi"] to fix the issue. 

#### How to Verify:

```
model_code = """
parameters {
    real a[10];
    real b[10];
    real c[100];
}
model {
    a ~ normal(0,1);
    b ~ normal(0,1);
    c ~ normal(0,1);
}
"""

sm = pystan.StanModel(model_code=model_code)
fit = sm.sampling(pars=["b", "c"])
print(fit.__repr__())
```

#### Side Effects:
-
#### Documentation:
-
#### Reviewer Suggestions: 

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):
Ari Hartikainen
By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: GPLv3 (http://opensource.org/licenses/GPL-3.0)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
