### PR TITLE
Fix chain summary order

### DIFF
--- a/pystan/misc.py
+++ b/pystan/misc.py
@@ -340,13 +340,13 @@ def _summary_sim(sim, pars, probs):
     msd = np.row_stack([x['msd'] for x in lmsdq])
     quan = np.row_stack([x['quan'] for x in lmsdq])
     probs_str = tuple(["{:g}%".format(100*p) for p in probs])
-    msd.shape = (tidx_len, 2)
-    quan.shape = (tidx_len, probs_len)
+    msd = msd.reshape(tidx_len, 2, order='F')
+    quan = quan.reshape(tidx_len, probs_len, order='F')
 
     c_msd = np.row_stack([x['c_msd'] for x in lmsdq])
     c_quan = np.row_stack([x['c_quan'] for x in lmsdq])
-    c_msd.shape = (tidx_len, 2, n_chains)
-    c_quan.shape = (tidx_len, probs_len, n_chains)
+    c_msd = c_msd.reshape(tidx_len, 2, n_chains, order='F')
+    c_quan = c_quan.reshape(tidx_len, probs_len, n_chains, order='F')
     sim_attr_args = sim.get('args', None)
     if sim_attr_args is None:
         cids = list(range(n_chains))


### PR DESCRIPTION
Fixes #646 

#### Summary:

Fix reshape order in `misc.summary`

#### Intended Effect:

Fix the order

#### How to Verify:

```
import pystan
import numpy as np

model_code = """
data {
    int<lower=1> N;
    matrix<lower=0>[N,N] Y;
} parameters {
    vector<lower=0>[N] x;
}
model {
    for (n in 1:N) {
        for (m in 1:N) {
            Y[n,m] ~ normal(x[n], x[m]);
        }
    }
}
"""

data = {
    "M" : 0,
    "W" : [],
    "N" : 10,
    "Y" : abs(np.random.randn(10, 10)) + 10
}

model = pystan.StanModel(model_code=model_code)
fit = model.sampling(data=data)

# See c_summary for 1st parameter for 1st chain
print(fit.summary()["c_summary"][0, :, 0])
print(fit.summary()["c_summary"][0, :, 1])

# Old
# [ 6.97519423  7.12671127  4.06515238 11.13487997  8.19061034  7.04062419  5.77473026]
# [ 1.80520175  1.83759254  5.6498625   4.1538856  10.95408163  8.31392122  6.96305573]

# Fixed 
# [ 7.27608044  1.8063694   4.31042482  5.95394985  7.12406486  8.51017979  11.0108483 ]
# [ 7.34285273  1.84917563  4.15944571  6.04566562  7.16175372  8.54397903  11.19322042]

```

#### Side Effects:

#### Documentation:

#### Reviewer Suggestions: 

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Ari Hartikainen

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: GPLv3 (http://opensource.org/licenses/GPL-3.0)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
