### PR TITLE
Update Stan source to v2.19.1

### DIFF
--- a/pystan/tests/test_extra_compile_args.py
+++ b/pystan/tests/test_extra_compile_args.py
@@ -40,7 +40,6 @@ class TestExtraCompileArgs(unittest.TestCase):
             pystan.StanModel(model_code=model_code, model_name="normal1",
                              extra_compile_args=extra_compile_args)
 
-    @unittest.skip("temporarily disabled due to STAN_THREADS issue in Stan 2.20")
     def test_threading_support(self):
         # Dont test with Windows with MinGW-w64 (GCC)
         if sys.platform.startswith("win"):


### PR DESCRIPTION
Reverts a disabled test (which was disabled for 2.20).