### PR TITLE
ci: Do not test on or build wheels for Python 3.5

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -13,7 +13,6 @@ environment:
 
   matrix:
     - CONDA: 27
-    - CONDA: 35
     - CONDA: 36
     - CONDA: 37
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,11 +18,9 @@ compiler:
   - gcc
 env:
   - TRAVIS_PYTHON_VERSION=2.7 TESTS_EXCLUDE_RE='^test_[a-p].*\.py'
-  - TRAVIS_PYTHON_VERSION=3.5 TESTS_EXCLUDE_RE='^test_[a-p].*\.py'
   - TRAVIS_PYTHON_VERSION=3.6 TESTS_EXCLUDE_RE='^test_[a-p].*\.py'
   - TRAVIS_PYTHON_VERSION=3.7 TESTS_EXCLUDE_RE='^test_[a-p].*\.py'
   - TRAVIS_PYTHON_VERSION=2.7 TESTS_EXCLUDE_RE='^test_[^a-p].*\.py'
-  - TRAVIS_PYTHON_VERSION=3.5 TESTS_EXCLUDE_RE='^test_[^a-p].*\.py'
   - TRAVIS_PYTHON_VERSION=3.6 TESTS_EXCLUDE_RE='^test_[^a-p].*\.py'
   - TRAVIS_PYTHON_VERSION=3.7 TESTS_EXCLUDE_RE='^test_[^a-p].*\.py'
 notifications:


### PR DESCRIPTION
Any objections? This only applies going forward. 2.19.1 has 3.5 wheels.