### PR TITLE
fix: Align `num_chains` default with RStan

### DIFF
--- a/stan/model.py
+++ b/stan/model.py
@@ -83,7 +83,7 @@ class Model:
 
         `num_chains` is the lone PyStan-specific keyword argument. It indicates
         the number of independent processes to use when drawing samples.
-        The default value is 1.
+        The default value is 4.
 
         Returns:
             Fit: instance of Fit allowing access to draws.
@@ -92,7 +92,8 @@ class Model:
         assert "chain" not in kwargs, "`chain` id is set automatically."
         assert "data" not in kwargs, "`data` is set in `build`."
         assert "random_seed" not in kwargs, "`random_seed` is set in `build`."
-        num_chains = kwargs.pop("num_chains", 1)
+
+        num_chains = kwargs.pop("num_chains", 4)
 
         init = kwargs.pop("init", [dict() for _ in range(num_chains)])
         if len(init) != num_chains:

--- a/tests/test_basic_bernoulli.py
+++ b/tests/test_basic_bernoulli.py
@@ -32,7 +32,7 @@ def fit(posterior):
 
 def test_bernoulli_sampling_thin(posterior):
     fit = posterior.sample(num_thin=2)
-    assert fit["theta"].shape[-1] == 500
+    assert fit["theta"].shape[-1] == 500 * 4
 
 
 def test_bernoulli_sampling_invalid_argument(posterior):

--- a/tests/test_normal.py
+++ b/tests/test_normal.py
@@ -15,10 +15,10 @@ def test_normal_sample():
     assert posterior is not None
     fit = posterior.sample()
     offset = len(fit.sample_and_sampler_param_names)
-    assert fit._draws.shape == (offset + 1, 1000, 1)  # 1 chain, n samples, 1 param
+    assert fit._draws.shape == (offset + 1, 1000, 4)  # 4 chains, n samples, 1 param
     df = fit.to_frame()
     assert (df["y"] == fit._draws[offset, :, :].ravel()).all()
-    assert len(df["y"]) == 1000
+    assert len(df["y"]) == 4000
     assert -0.01 < df["y"].mean() < 0.01
     assert -0.01 < df["y"].std() < 0.01
 
@@ -43,5 +43,5 @@ def test_normal_sample_args():
     assert posterior is not None
     fit = posterior.sample(num_samples=350, num_thin=2)
     df = fit.to_frame()
-    assert len(df["y"]) == 350 // 2
+    assert len(df["y"]) == 350 * 4 // 2
     assert -5 < df["y"].mean() < 5


### PR DESCRIPTION
Sample using 4 independent chains by default. This is the
default in RStan. It's also the default in PyStan 2.