### PR TITLE
fix: Correctly use default class instance pickler

### DIFF
--- a/stan/fit.py
+++ b/stan/fit.py
@@ -190,11 +190,11 @@ class Fit(collections.abc.Mapping):
 
         def calculate_starts(dims: Tuple[Tuple[int, ...]]) -> Tuple[int, ...]:
             """Calculate starting indexes given dims."""
-            s = [np.prod(d) for d in dims]
+            s = [cast(int, np.prod(d)) for d in dims]
             starts = np.cumsum([0] + s)[: len(dims)]
             return tuple(int(i) for i in starts)
 
         starts = tuple(sample_and_sampler_params_offset + i for i in calculate_starts(self.dims))
         names_index = self.param_names.index(param)
-        flat_param_count = np.prod(self.dims[names_index])
+        flat_param_count = cast(int, np.prod(self.dims[names_index]))
         return tuple(starts[names_index] + offset for offset in range(flat_param_count))

--- a/tests/test_pickle.py
+++ b/tests/test_pickle.py
@@ -1,0 +1,25 @@
+import pickle
+import tempfile
+
+import numpy as np
+import pytest
+
+import stan
+
+program_code = "parameters {real y;} model {y ~ normal(0,1);}"
+
+
+@pytest.fixture(scope="module")
+def normal_posterior():
+    return stan.build(program_code)
+
+
+def test_pickle(normal_posterior):
+    fit1 = normal_posterior.sample(stepsize=0.001)
+    assert fit1["y"] is not None
+    with tempfile.TemporaryFile() as fp:
+        pickle.dump(fit1, fp)
+        fp.seek(0)
+        fit2 = pickle.load(fp)
+    assert fit2["y"] is not None
+    np.testing.assert_array_equal(fit1["y"], fit2["y"])


### PR DESCRIPTION
Correctly use the default class instance pickler.  Previously the code
relied on the class's `__init__` method being called when the instance was
unpickled.  Python's default class instance pickler does not call the
`__init__` method. It calls `__new__` and then updates the instance's class
dictionary. Relevant section of the Python docs:
https://docs.python.org/3/library/pickle.html#pickling-class-instances

Closes #201