### PR TITLE
feat: Make Model a frozen dataclass

### DIFF
--- a/stan/model.py
+++ b/stan/model.py
@@ -1,5 +1,6 @@
 import asyncio
 import collections.abc
+import dataclasses
 import json
 import re
 from typing import List, Optional, Tuple
@@ -52,6 +53,7 @@ def _make_json_serializable(data: dict) -> dict:
     return data
 
 
+@dataclasses.dataclass(frozen=True)
 class Model:
     """Stores data associated with and proxies calls to a Stan model.
 
@@ -59,25 +61,17 @@ class Model:
 
     """
 
-    def __init__(
-        self,
-        model_name: str,
-        program_code: str,
-        data: dict,
-        param_names: Tuple[str, ...],
-        constrained_param_names: Tuple[str, ...],
-        dims: Tuple[Tuple[int, ...]],
-        random_seed: Optional[int],
-    ) -> None:
-        if model_name != httpstan.models.calculate_model_name(program_code):
+    model_name: str
+    program_code: str
+    data: dict
+    param_names: Tuple[str, ...]
+    constrained_param_names: Tuple[str, ...]
+    dims: Tuple[Tuple[int, ...]]
+    random_seed: Optional[int]
+
+    def __post_init__(self):
+        if self.model_name != httpstan.models.calculate_model_name(self.program_code):
             raise ValueError("`model_name` does not match `program_code`.")
-        self.model_name = model_name
-        self.program_code = program_code
-        self.data = data or {}
-        self.param_names = param_names
-        self.constrained_param_names = constrained_param_names
-        self.dims = dims
-        self.random_seed = random_seed
 
     def sample(self, **kwargs) -> stan.fit.Fit:
         """Draw samples from the model.

--- a/stan/model.py
+++ b/stan/model.py
@@ -89,7 +89,6 @@ class Model:
             Fit: instance of Fit allowing access to draws.
 
         """
-        assert isinstance(self.data, dict)
         assert "chain" not in kwargs, "`chain` id is set automatically."
         assert "data" not in kwargs, "`data` is set in `build`."
         assert "random_seed" not in kwargs, "`random_seed` is set in `build`."
@@ -194,7 +193,6 @@ class Model:
                 parser = simdjson.Parser()
                 nonstandard_logger_messages = []
                 for stan_output in stan_outputs:
-                    assert isinstance(stan_output, bytes)
                     for line in stan_output.splitlines():
                         # Do not attempt to parse non-logger messages. Draws could contain nan or inf values.
                         # simdjson cannot parse lines containing such values.
@@ -258,8 +256,6 @@ class Model:
             The unconstrained parameters are passed to the `write_array` method of the `model_base`
             instance. See `model_base.hpp` in the Stan C++ library for details.
         """
-        assert isinstance(self.data, dict)
-
         payload = {
             "data": self.data,
             "unconstrained_parameters": unconstrained_parameters,
@@ -292,8 +288,6 @@ class Model:
             The unconstrained parameters are passed to the `transform_inits` method of the
             `model_base` instance. See `model_base.hpp` in the Stan C++ library for details.
         """
-        assert isinstance(self.data, dict)
-
         payload = {"data": self.data, "constrained_parameters": constrained_parameters}
 
         async def go():
@@ -322,8 +316,6 @@ class Model:
             function in stan::model.
 
         """
-        assert isinstance(self.data, dict)
-
         payload = {
             "data": self.data,
             "unconstrained_parameters": unconstrained_parameters,


### PR DESCRIPTION
Make Model a frozen dataclass. Making `Model` an
immutable dataclass has many benefits. We get
`__eq__` and `__hash__`, for example.

6 fewer lines, too. h/t [PEP557](https://www.python.org/dev/peps/pep-0557/)