### PR TITLE
docs: Update package and docs links

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,8 +9,8 @@ authors = [
 license = "ISC"
 readme = "README.rst"
 homepage = "https://mc-stan.org"
-repository = "https://github.com/stan-dev/pystan-next"
-documentation = "https://pystan-next.readthedocs.io"
+repository = "https://github.com/stan-dev/pystan"
+documentation = "https://pystan.readthedocs.io"
 packages = [
     { include = "stan" },
 ]


### PR DESCRIPTION
Replace `pystan-next` with `pystan`