### PR TITLE
feat: Scalar numpy dtypes to json

### DIFF
--- a/stan/model.py
+++ b/stan/model.py
@@ -42,9 +42,8 @@ def _make_json_serializable(data: dict) -> dict:
             pass
         else:
             continue
-        # numpy scalar
-        if isinstance(value, np.ndarray) and value.ndim == 0:
-            data[key] = np.asarray(value).tolist()
+        if type(value).__module__ == "numpy":
+            data[key] = value.tolist()
         # numpy.ndarray, pandas.Series, and anything similar
         elif isinstance(value, collections.abc.Collection):
             data[key] = np.asarray(value).tolist()
@@ -113,13 +112,11 @@ class Model:
             # progress bar needs to know some of these
             num_warmup = payload.get("num_warmup", arguments.lookup_default(arguments.Method["SAMPLE"], "num_warmup"))
             num_samples = payload.get(
-                "num_samples",
-                arguments.lookup_default(arguments.Method["SAMPLE"], "num_samples"),
+                "num_samples", arguments.lookup_default(arguments.Method["SAMPLE"], "num_samples")
             )
             num_thin = payload.get("num_thin", arguments.lookup_default(arguments.Method["SAMPLE"], "num_thin"))
             save_warmup = payload.get(
-                "save_warmup",
-                arguments.lookup_default(arguments.Method["SAMPLE"], "save_warmup"),
+                "save_warmup", arguments.lookup_default(arguments.Method["SAMPLE"], "save_warmup")
             )
             payloads.append(payload)
 
@@ -351,10 +348,7 @@ class Model:
         """
         assert isinstance(self.data, dict)
 
-        payload = {
-            "data": self.data,
-            "unconstrained_parameters": unconstrained_parameters,
-        }
+        payload = {"data": self.data, "unconstrained_parameters": unconstrained_parameters}
 
         async def go():
             async with stan.common.HttpstanClient() as client:

--- a/tests/test_data_validation.py
+++ b/tests/test_data_validation.py
@@ -22,8 +22,8 @@ def test_make_json_serializable():
 
 
 def test_make_json_serializable_numpy():
-    data = {"K": 3, "x": np.array([3, 4, 5])}
-    expected = {"K": 3, "x": [3, 4, 5]}
+    data = {"int": np.int32(3), "float": np.float64(3), "array": np.array([1, 2, 3])}
+    expected = {"int": 3, "float": 3.0, "array": [1, 2, 3]}
     assert stan.model._make_json_serializable(data) == expected
     assert json.dumps(stan.model._make_json_serializable(data))
 


### PR DESCRIPTION
This PR sanitizes numpy integer and float values to be JSON compatible.

Fixes #226 