### PR TITLE
style: Remove unnecessary assertion

### DIFF
--- a/stan/model.py
+++ b/stan/model.py
@@ -351,8 +351,6 @@ class Model:
             The unconstrained parameters are passed to the log_prob_grad
             function in stan::model.
         """
-        assert isinstance(self.data, dict)
-
         payload = {
             "data": self.data,
             "unconstrained_parameters": unconstrained_parameters,


### PR DESCRIPTION
Remove an unnecessary assertion. The type for `data` is well-documented
and checked by the type checker.