### PR TITLE
feat: Pin httpstan to major.minor version for reproducibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 [tool.poetry.dependencies]
 python = "^3.7"
 aiohttp = "^3.6"
-httpstan = "^4.3.2"
+httpstan = "~4.4"
 pysimdjson = "^3.2"
 numpy = "^1.7"
 clikit = "^0.6"


### PR DESCRIPTION
Pin httpstan to major.minor version for reproducibility.
With this change, a given version of pystan will use a specific version
of Stan.  Previously a single version of pystan can use many different
versions of httpstan. Because the version of Stan is tied to the version
of httpstan, pystan could end up using a wide range of Stan versions.
Such behavior is inimical to reproducible research.

Closes #241