### PR TITLE
ci: Use macos 10.15

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ jobs:
     timeout-minutes: 20
     strategy:
       matrix:
-        os: [ubuntu-20.04, macos-10.14]
+        os: [ubuntu-20.04, macos-10.15]
         python-version: [3.7, 3.8]
     steps:
       - name: Check out repository


### PR DESCRIPTION
Use macos 10.15. Addresses Github Actions warning.