### PR TITLE
docs: Improve documentation for num_chains and init

### DIFF
--- a/doc/reference.rst
+++ b/doc/reference.rst
@@ -5,11 +5,11 @@ API Reference
 .. automodule:: stan
    :members: build
 
-.. automodule:: stan.fit
-   :members: Fit
-
 .. automodule:: stan.model
    :members: Model
+
+.. automodule:: stan.fit
+   :members: Fit
 
 .. automodule:: stan.plugins
    :members: PluginBase

--- a/stan/model.py
+++ b/stan/model.py
@@ -2,7 +2,7 @@ import asyncio
 import dataclasses
 import json
 import re
-from typing import Dict, Optional, Sequence, Tuple, Union
+from typing import Dict, List, Optional, Sequence, Tuple, Union
 
 import httpstan.models
 import httpstan.schemas
@@ -70,6 +70,16 @@ class Model:
         Returns:
             Fit: instance of Fit allowing access to draws.
 
+        Examples:
+            User-defined initial values for parameters must be provided
+            for each chain. Typically they will be the same for each chain.
+            The following example shows how user-defined initial parameters
+            are provided:
+
+            >>> program_code = "parameters {real y;} model {y ~ normal(0,1);}"
+            >>> posterior = stan.build(program_code)
+            >>> fit = posterior.sample(num_chains=2, init=[{"y": 3}, {"y": 3}])
+
         """
         return self.hmc_nuts_diag_e_adapt(num_chains=num_chains, **kwargs)
 
@@ -134,6 +144,7 @@ class Model:
         payload = json.loads(DataJSONEncoder().encode(payload))
         num_chains = payload.pop("num_chains")
 
+        init: List[Data]
         init = payload.pop("init", [dict() for _ in range(num_chains)])
         if len(init) != num_chains:
             raise ValueError("Initial values must be provided for each chain.")

--- a/tests/test_eight_schools.py
+++ b/tests/test_eight_schools.py
@@ -78,3 +78,10 @@ def test_eight_schools_parameter_indexes(posterior):
     assert fit._parameter_indexes("tau") == (offset + 1,)
     assert fit._parameter_indexes("eta") == tuple(offset + i for i in (2, 3, 4, 5, 6, 7, 8, 9))
     assert fit._parameter_indexes("theta") == tuple(offset + i for i in (10, 11, 12, 13, 14, 15, 16, 17))
+
+
+def test_eight_schools_positional_argument(posterior):
+    """`sample` does not allow positional arguments."""
+    num_chains = 2
+    with pytest.raises(TypeError, match=r"sample\(\) takes 1 positional argument"):
+        posterior.sample(num_chains)


### PR DESCRIPTION
Document default for num_chains in function signature. Show an example of providing initial values for parameters.