### PR TITLE
fix: Use different payloads for different chains

### DIFF
--- a/stan/model.py
+++ b/stan/model.py
@@ -169,7 +169,7 @@ class Model:
                 "save_warmup",
                 arguments.lookup_default(arguments.Method["SAMPLE"], "save_warmup"),
             )
-            payloads.append(payload)
+            payloads.append(payload.copy())
 
         async def go():
             io = ConsoleIO()


### PR DESCRIPTION
Currently, the output of all the chains were the same.
Steps to reproduce:
```python
schools_code = """
data {
  int<lower=0> J;         // number of schools
  real y[J];              // estimated treatment effects
  real<lower=0.0> sigma[J]; // standard error of effect estimates
}
parameters {
  real mu;                // population treatment effect
  real<lower=0> tau;      // standard deviation in treatment effects
  vector[J] eta;          // unscaled deviation from mu by school
}
transformed parameters {
  vector[J] theta = mu + tau * eta;        // school treatment effects
}
model {
  target += normal_lpdf(eta | 0, 1);       // prior log-density
  target += normal_lpdf(y | theta, sigma); // log-likelihood
}
"""
schools_data = {"J": 8,
                "y": [28,  8, -3,  7, -1,  1, 18, 12],
                "sigma": [15, 10, 16, 11,  9, 11, 10, 18]}
posterior = stan.build(schools_code, data=schools_data, random_seed=1)
fit = posterior.hmc_nuts_diag_e_adapt(num_chains=2, num_samples=10)
```
This happened because there was a single payload that was being modified for all the chains.                 