### PR TITLE
chore: Add GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,34 @@
+---
+name: Bug report
+about: Create a bug report
+title: ""
+labels: "bug"
+---
+
+<!--
+Before submitting a bug, please make sure the issue hasn't been already
+addressed by searching through the past issues.
+-->
+
+#### Describe the bug
+<!--
+A clear and concise description of what the bug is.
+-->
+
+#### Steps/Code to Reproduce
+<!--
+Please add a minimal example that we can reproduce the error by running the
+code. Be as succinct as possible, do not depend on external data. In short, we
+are going to copy-paste your code and we expect to get the same
+result as you.
+
+**Note**: Please read [this guide](https://matthewrocklin.com/blog/work/2018/02/28/minimal-bug-reports) detailing how to provide the necessary information for us to reproduce your bug.
+
+#### Code Sample, a copy-pastable example
+
+```python
+# Your code here
+
+```
+
+<!-- Thanks for the report! -->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,7 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Ask a question on the Stan Forums
+    url: https://discourse.mc-stan.org/
+  - name: Blank issue
+    url: https://github.com/stan-dev/pystan/issues/new
+    about: Please note that the Stan Forums should be used in most cases

--- a/.github/ISSUE_TEMPLATE/documentation_improvement.md
+++ b/.github/ISSUE_TEMPLATE/documentation_improvement.md
@@ -1,0 +1,19 @@
+---
+name: Documentation improvement
+about: Create a report to help us improve the documentation. Alternatively you can just open a pull request with the suggested change.
+title: ''
+labels: documentation
+assignees: ''
+---
+
+#### Describe the problem with the documentation
+
+<!--
+Tell us about the confusion introduced in the documentation.
+-->
+
+#### Suggest a potential alternative/fix
+
+<!--
+Tell us how we could improve the documentation in this regard.
+-->


### PR DESCRIPTION
Use GitHub issue templates to indicate that GitHub issues
are for bug reports and documentation improvements only.
Everything else should go to the Stan Forums.