### PR TITLE
docs: Fixup Model.grad_log_prob docstring

### DIFF
--- a/stan/model.py
+++ b/stan/model.py
@@ -402,10 +402,9 @@ class Model:
 
         Arguments:
             unconstrained_parameters: A sequence of unconstrained parameters.
-            adjust_transform: Apply jacobian adjust transform.
 
         Returns:
-            The gradient of the log posterior evalauted at the
+            The gradient of the log posterior evaluated at the
             unconstrained parameters.
 
         Notes:


### PR DESCRIPTION
Docstring of `grad_log_prob` referenced an argument `adjust_transform` that does not exist. Also fixed a typo "evalauted" -> "evaluated".

Minor point, but figured I'd throw a fix up anyways