### PR TITLE
docs: Avoid suggesting support for numpy types

### DIFF
--- a/stan/model.py
+++ b/stan/model.py
@@ -17,11 +17,13 @@ import stan.common
 import stan.fit
 import stan.plugins
 
-Data = Dict[str, Union[int, float, Sequence[Union[int, float]], np.ndarray]]
+Data = Dict[str, Union[int, float, Sequence[Union[int, float]]]]
 
 
 class DataJSONEncoder(json.JSONEncoder):
     def default(self, obj):
+        # numpy.ndarray is *unofficially* supported as there is no easy way to
+        # construct tabular data using the Python standard library.
         if isinstance(obj, np.ndarray):
             return obj.tolist()
         return json.JSONEncoder.default(self, obj)


### PR DESCRIPTION
Remove the suggestion that the `Data` type accepts
`ndarray`s. (These are still unofficially supported.)

This simplifies the type, making it easier to read. This may help users
avoid assuming that arbitrary numpy types will be accepted as data.

PyStan barely depends on numpy. In the future, the dependency may be
removed. (NumPy is a serious dependency, wheel is ~16MB.) In the
meantime, users should be encouraged to interact with PyStan as if it
the package did not know about the existence of numpy.