### PR TITLE
feat: Convert numpy integers in `data` to Python int

### DIFF
--- a/stan/model.py
+++ b/stan/model.py
@@ -24,6 +24,9 @@ class DataJSONEncoder(json.JSONEncoder):
     def default(self, obj):
         if isinstance(obj, np.ndarray):
             return obj.tolist()
+        # unofficially support np.int64, np.int32, etc.
+        if hasattr(obj, "dtype") and np.issubdtype(obj.dtype, np.integer):
+            return int(obj)
         return json.JSONEncoder.default(self, obj)
 
 

--- a/tests/test_numpy_data.py
+++ b/tests/test_numpy_data.py
@@ -1,0 +1,33 @@
+import numpy as np
+import pytest
+
+import stan
+
+program_code = """
+    data {
+    int<lower=0> N;
+    int<lower=0,upper=1> y[N];
+    }
+    parameters {
+    real<lower=0,upper=1> theta;
+    }
+    model {
+    for (n in 1:N)
+        y[n] ~ bernoulli(theta);
+    }
+    """
+
+
+def test_unsupported_type():
+    data = {"N": np.float32(10), "y": [0, 1, 0, 0, 0, 0, 0, 0, 0, 1]}
+    with pytest.raises(TypeError, match="Object of type float32 is not JSON serializable"):
+        stan.build(program_code, data=data, random_seed=1)
+
+
+def test_numpy_integer_types():
+    data = {"N": np.int64(10), "y": [0, 1, 0, 0, 0, 0, 0, 0, 0, 1]}
+    assert stan.build(program_code, data=data, random_seed=1) is not None
+    data = {"N": np.int32(10), "y": [0, 1, 0, 0, 0, 0, 0, 0, 0, 1]}
+    assert stan.build(program_code, data=data, random_seed=1) is not None
+    data = {"N": np.int16(10), "y": [0, 1, 0, 0, 0, 0, 0, 0, 0, 1]}
+    assert stan.build(program_code, data=data, random_seed=1) is not None


### PR DESCRIPTION
This commit makes it easier to use PyStan with numpy integer types.
Numpy integers will be silently converted to Python ints. There
is no loss of precision, risk of overflow, etc.

Note that this adds support in PyStan only for numpy integer types.
Floats are more complicated because Python floats are not necessarily
compatible with numpy floats (e.g., np.float128).

Closes #326