### PR TITLE
Add runtime dependency on setuptools

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ httpstan = "~4.6"
 pysimdjson = "^3.2"
 numpy = "^1.7"
 clikit = "^0.6"
+setuptools = "*"
 
 [tool.poetry.dev-dependencies]
 pytest = "^5.4"


### PR DESCRIPTION
pystan imports `pkg_resources` (provided by `setuptools`): https://github.com/stan-dev/pystan/blob/50670e465e13e6d74ea506773eaa36633b5ad4ea/stan/plugins.py#L4

an alternative implementation would be to use `importlib.metadata` (or the `importlib-metadata` backport)