### PR TITLE
docs: Remove outdated mention of Python 3.7

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -19,7 +19,7 @@ Notable features of PyStan include:
 Getting started
 ===============
 
-Install PyStan with ``pip install pystan``. PyStan requires Python ≥3.7 running on Linux or macOS. You will also need a C++ compiler such as gcc ≥9.0 or clang ≥10.0.
+Install PyStan with ``pip install pystan``. PyStan runs on Linux and macOS. You will also need a C++ compiler such as gcc ≥9.0 or clang ≥10.0.
 
 The following block of code shows how to use PyStan with a model which studied coaching effects across eight schools (see Section 5.5 of Gelman et al (2003)). This hierarchical model is often called the "eight schools" model.
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -24,7 +24,7 @@ Notable features of PyStan include:
 Quick start
 ===========
 
-Install PyStan with ``python3 -m pip install pystan``. PyStan requires Python ≥3.7 running on Linux or macOS. You will also need a C++ compiler such as gcc ≥9.0 or clang ≥10.0.
+Install PyStan with ``python3 -m pip install pystan``. PyStan runs on Linux and macOS. You will also need a C++ compiler such as gcc ≥9.0 or clang ≥10.0.
 
 This block of code shows how to use PyStan with a hierarchical model used to study coaching effects across eight schools (see Section 5.5 of Gelman et al. (2003)).
 

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -4,7 +4,6 @@ Installation
 
 In order to install PyStan from PyPI make sure your system satisfies the requirements:
 
-- Python ≥3.7
 - Linux or macOS
 - x86-64 CPU
 - C++ compiler: gcc ≥9.0 or clang ≥10.0.

--- a/doc/upgrading.rst
+++ b/doc/upgrading.rst
@@ -7,7 +7,7 @@ Upgrading to Newer Releases
 Upgrading to 3.0
 ================
 
-PyStan 3 is a complete rewrite. PyStan requires Python ≥3.7 running on Linux or macOS.
+PyStan 3 is a complete rewrite. PyStan runs on Linux and macOS.
 
 PyStan 3 makes numerous **backwards-incompatible changes**.
 Many of these changes are introduced to harmonize variable naming practices across the numerous interfaces to the Stan C++ library.


### PR DESCRIPTION
Supported versions of Python are now reliably communicated via PyPI.