### PR TITLE
fix: Update `num_samples_saved` formula in `fit.py`

### DIFF
--- a/stan/fit.py
+++ b/stan/fit.py
@@ -1,5 +1,6 @@
 import collections
 import json
+from math import ceil
 from typing import Generator, Tuple, cast
 
 import numpy as np
@@ -41,6 +42,8 @@ class Fit(collections.abc.Mapping):
             constrained_param_names,
         )
         self.num_warmup, self.num_samples = num_warmup, num_samples
+        if not isinstance(num_thin, int):
+            raise ValueError(f"{type(num_thin)} object cannot be interpreted as an integer: num_thin={num_thin}")
         self.num_thin, self.save_warmup = num_thin, save_warmup
 
         # `self.sample_and_sampler_param_names` collects the sample and sampler param names.
@@ -51,7 +54,9 @@ class Fit(collections.abc.Mapping):
 
         num_flat_params = sum(np.product(dims_ or 1) for dims_ in dims)  # if dims == [] then it is a scalar
         assert num_flat_params == len(constrained_param_names)
-        num_samples_saved = (self.num_samples + self.num_warmup * self.save_warmup) // self.num_thin
+        num_samples_saved = ceil(self.num_samples / self.num_thin) + ceil(
+            (self.num_warmup * self.save_warmup) / self.num_thin
+        )
 
         # self._draws holds all the draws. We cannot allocate it before looking at the draws
         # because we do not know how many sampler-specific parameters are present. Later in this
@@ -124,7 +129,7 @@ class Fit(collections.abc.Mapping):
         param_indexes = self._parameter_indexes(param)
         param_dim = [] if param in self.sample_and_sampler_param_names else self.dims[self.param_names.index(param)]
         # fmt: off
-        num_samples_saved = (self.num_samples + self.num_warmup * self.save_warmup) // self.num_thin
+        num_samples_saved = ceil(self.num_samples / self.num_thin) + ceil((self.num_warmup * self.save_warmup) / self.num_thin)
         assert self._draws.shape == (len(self.sample_and_sampler_param_names) + len(self.constrained_param_names), num_samples_saved, self.num_chains)
         # fmt: on
         if not len(param_indexes):

--- a/tests/test_basic_bernoulli.py
+++ b/tests/test_basic_bernoulli.py
@@ -42,8 +42,8 @@ def test_bernoulli_fixed_param(posterior):
 
 
 def test_bernoulli_sampling_invalid_argument(posterior):
-    with pytest.raises(TypeError, match=r"'float' object cannot be interpreted as an integer"):
-        posterior.sample(num_thin=2.0)
+    with pytest.raises(ValueError, match="<class 'float'> object cannot be interpreted as an integer"):
+        posterior.sample(num_thin=2.5)
 
 
 def test_bernoulli_sampling(fit):

--- a/tests/test_normal.py
+++ b/tests/test_normal.py
@@ -1,3 +1,5 @@
+from math import ceil
+
 import stan
 
 
@@ -41,7 +43,7 @@ def test_normal_sample_args():
     program_code = "parameters {real y;} model {y ~ normal(0,1);}"
     posterior = stan.build(program_code, random_seed=1)
     assert posterior is not None
-    fit = posterior.sample(num_samples=350, num_thin=2)
+    fit = posterior.sample(num_samples=350, num_warmup=350, num_thin=3, save_warmup=True)
     df = fit.to_frame()
-    assert len(df["y"]) == 350 * 4 // 2
+    assert len(df["y"]) == ceil(350 / 3) * 2 * 4
     assert -5 < df["y"].mean() < 5


### PR DESCRIPTION
Fixes #366 

Fixes the formula to calculate `num_samples_saved`.
Updates a test in `tests/test_normal.py` to hit this specific problem for both `num_samples` and `num_warmup` when `save_warmup=True`.