### PR TITLE
ci: Use macos-12 runner for Python 3.10

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
           - {runs-on: ubuntu-22.04, python-version: "3.10"}
           - {runs-on: macos-11, python-version: "3.8"}
           - {runs-on: macos-11, python-version: "3.9"}
-          - {runs-on: macos-11, python-version: "3.10"}
+          - {runs-on: macos-12, python-version: "3.10"}
     steps:
       - name: Check out repository
         uses: actions/checkout@v3


### PR DESCRIPTION
Possible fix for PyPI installation issue.

Perhaps macos-12 can install our python 3.10 wheel on PyPI.