### PR TITLE
feat: Use Stan 2.32.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pystan"
-version = "3.6.0"
+version = "3.7.0"
 description = "Python interface to Stan, a package for Bayesian inference"
 authors = [
   "Allen Riddell <riddella@indiana.edu>",
@@ -24,7 +24,7 @@ classifiers = [
 [tool.poetry.dependencies]
 python = "^3.8"
 aiohttp = "^3.6"
-httpstan = "~4.9"
+httpstan = "~4.10"
 pysimdjson = "^5.0.2"
 numpy = "^1.19"
 clikit = "^0.6"


### PR DESCRIPTION
httpstan now at 4.10.0 (Stan 2.32.0).

Pin httpstan to >=4.10,<4.11.

Reminder that in poetry, a tilde version requirement pins the minor version. That is, ~1.2.3 means >=1.2.3,<1.3.0.