### PR TITLE
feat: Use Stan 2.33.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pystan"
-version = "3.7.0"
+version = "3.8.0"
 description = "Python interface to Stan, a package for Bayesian inference"
 authors = [
   "Allen Riddell <riddella@indiana.edu>",
@@ -24,7 +24,7 @@ classifiers = [
 [tool.poetry.dependencies]
 python = "^3.8"
 aiohttp = "^3.6"
-httpstan = "~4.10"
+httpstan = "~4.11"
 pysimdjson = "^5.0.2"
 numpy = "^1.19"
 clikit = "^0.6"

--- a/tests/test_eight_schools.py
+++ b/tests/test_eight_schools.py
@@ -16,7 +16,7 @@ program_code = """
       array[J] real eta;
     }
     transformed parameters {
-      real theta[J];
+      array[J] real theta;
       for (j in 1:J)
         theta[j] = mu + tau * eta[j];
     }

--- a/tests/test_fit_basic_matrix.py
+++ b/tests/test_fit_basic_matrix.py
@@ -21,7 +21,7 @@ program_code = """
      model {
      for (k in 1:K)
          for (d in 1:D)
-           beta[k,d] ~ normal(if_else(d==2, 5, 0), 0.000001);
+           beta[k,d] ~ normal(d==2 ? 5 : 0, 0.000001);
      }
 """
 K, D = 3, 4

--- a/tests/test_fit_shape.py
+++ b/tests/test_fit_shape.py
@@ -20,37 +20,36 @@ program_code = """
       array[L, M] real B;
       vector[N] c;
       matrix[O, P] D;
-      matrix[R, S] E[Q];
+      array[Q] matrix[R, S] E;
     }
     model {
-      for (k in 1:K) {
+      for (k in 1 : K) {
         a[k] ~ std_normal();
       }
 
-      for (l in 1:L) {
-        for (m in 1:M) {
+      for (l in 1 : L) {
+        for (m in 1 : M) {
           B[l, m] ~ std_normal();
         }
       }
 
-      for (n in 1:N) {
+      for (n in 1 : N) {
         c[n] ~ std_normal();
       }
 
-      for (o in 1:O) {
-        for (p in 1:P) {
+      for (o in 1 : O) {
+        for (p in 1 : P) {
           D[o, p] ~ std_normal();
         }
       }
 
-      for (q in 1:Q) {
-        for (r in 1:R) {
-          for (s in 1:S) {
+      for (q in 1 : Q) {
+        for (r in 1 : R) {
+          for (s in 1 : S) {
             E[q, r, s] ~ std_normal();
           }
         }
       }
-
     }
 """
 num_samples = 100

--- a/tests/test_stanc_warnings.py
+++ b/tests/test_stanc_warnings.py
@@ -29,23 +29,3 @@ def test_stanc_unused_warning() -> None:
     with contextlib.redirect_stderr(buffer):
         stan.build(program_code=program_code)
     assert "The parameter y was declared but was not used in the density" in buffer.getvalue()
-
-
-def test_stanc_assignment_warning() -> None:
-    """Test that stanc warning is shown to user."""
-    # stanc prints warning:
-    # assignment operator <- is deprecated in the Stan language; use = instead.
-    program_code = """
-    parameters {
-    real y;
-    }
-    model {
-    real x;
-    x <- 5;
-    y ~ normal(0,1);
-    }
-    """
-    buffer = io.StringIO()
-    with contextlib.redirect_stderr(buffer):
-        stan.build(program_code=program_code)
-    assert "operator <- is deprecated in the Stan language and will be removed" in buffer.getvalue(), buffer.getvalue()


### PR DESCRIPTION
httpstan now at 4.11.0 (Stan 2.33.0).

Pin httpstan to >=4.11,<4.12.

Reminder that in poetry, a tilde version requirement pins the minor version. That is, ~1.2.3 means >=1.2.3,<1.3.0.