### PR TITLE
chore: Update supported Pythons, drop 3.9

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,14 +10,12 @@ jobs:
     strategy:
       matrix:
         include:
-          - {runs-on: ubuntu-20.04, python-version: "3.8"}
-          - {runs-on: ubuntu-20.04, python-version: "3.9"}
           - {runs-on: ubuntu-22.04, python-version: "3.10"}
           - {runs-on: ubuntu-22.04, python-version: "3.11"}
-          - {runs-on: macos-11, python-version: "3.8"}
-          - {runs-on: macos-11, python-version: "3.9"}
+          - {runs-on: ubuntu-22.04, python-version: "3.12"}
           - {runs-on: macos-11, python-version: "3.10"}
           - {runs-on: macos-11, python-version: "3.11"}
+          - {runs-on: macos-11, python-version: "3.12"}
     steps:
       - name: Check out repository
         uses: actions/checkout@v3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
 ]
 
 [tool.poetry.dependencies]
-python = "^3.8"
+python = "^3.10"
 aiohttp = "^3.6"
 httpstan = "~4.11"
 pysimdjson = "^5.0.2"


### PR DESCRIPTION
Drop support for Python 3.9 on April 5, 2024 following NEP 29 https://numpy.org/neps/nep-0029-deprecation_policy.html

Test against Python 3.12 in CI.

Do not merge this until April 2024.