### PR TITLE
docs: Update faq.rst with info about poetry version

### DIFF
--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -98,7 +98,7 @@ with the following steps:
 
    a. Build shared libraries by typing ``make`` into the terminal.
    b. Build the httpstan wheel on your system by typing ``python3 -m pip 
-      install poetry`` followed by ``python3 -m poetry build`` into the
+      install poetry==1.1.15`` followed by ``python3 -m poetry build`` into the
       terminal.
    c. Install the wheel by typing ``python3 -m pip install dist/*.whl`` into
       the terminal.


### PR DESCRIPTION
On M3 apple silicon the build does not work with `poetry>1.1.15` and `httpstan==4.11.0`. Recent `poetry` version (1.7.1) require `crashtest = "^0.4.1"` (see logs from the error below):

```
poetry 1.7.1 requires crashtest<0.5.0,>=0.4.1, but you have crashtest 0.3.1 which is incompatible.
```

while `pystan` has a transitive dependency on `crashtest<0.4.0,>=0.3.0` via `clikit<0.7,>=0.6`. 


I managed to get it working with `poetry==1.1.15`