### PR TITLE
ci: bump github actions versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,10 +20,10 @@ jobs:
           - {runs-on: macos-11, python-version: "3.12"}
     steps:
       - name: Check out repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -7,9 +7,9 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.11"
       - name: Install dependencies


### PR DESCRIPTION
Hi, this is my first PR to the project.

This PR bumps the versions of the used GitHub Actions, which will get rid of the warnings (e.g. Node.js 16 actions are deprecated. [...] in the [Annotations section under Actions](https://github.com/stan-dev/pystan/actions/runs/8663544649).